### PR TITLE
Fix PicoSDK ComputerCard template

### DIFF
--- a/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/CMakeLists.txt
+++ b/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/CMakeLists.txt
@@ -1,3 +1,20 @@
+# == DO NOT EDIT THE FOLLOWING LINES for the Raspberry Pi Pico VS Code Extension to work ==
+if(WIN32)
+    set(USERHOME $ENV{USERPROFILE})
+else()
+    set(USERHOME $ENV{HOME})
+endif()
+set(sdkVersion 2.1.0)
+set(toolchainVersion 13_3_Rel1)
+set(picotoolVersion 2.1.0)
+set(picoVscode ${USERHOME}/.pico-sdk/cmake/pico-vscode.cmake)
+if (EXISTS ${picoVscode})
+    include(${picoVscode})
+endif()
+# ====================================================================================
+set(PICO_BOARD wscomputer CACHE STRING "Board type")
+set(PICO_BOARD_HEADER_DIRS ${CMAKE_CURRENT_LIST_DIR})
+
 cmake_minimum_required (VERSION 3.13)
 include(pico_sdk_import.cmake)
 project(computercard C CXX ASM)

--- a/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/CMakeLists.txt
+++ b/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/CMakeLists.txt
@@ -1,17 +1,3 @@
-# == DO NOT EDIT THE FOLLOWING LINES for the Raspberry Pi Pico VS Code Extension to work ==
-if(WIN32)
-    set(USERHOME $ENV{USERPROFILE})
-else()
-    set(USERHOME $ENV{HOME})
-endif()
-set(sdkVersion 2.1.0)
-set(toolchainVersion 13_3_Rel1)
-set(picotoolVersion 2.1.0)
-set(picoVscode ${USERHOME}/.pico-sdk/cmake/pico-vscode.cmake)
-if (EXISTS ${picoVscode})
-    include(${picoVscode})
-endif()
-# ====================================================================================
 set(PICO_BOARD wscomputer CACHE STRING "Board type")
 set(PICO_BOARD_HEADER_DIRS ${CMAKE_CURRENT_LIST_DIR})
 

--- a/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/CMakeLists.txt
+++ b/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/CMakeLists.txt
@@ -18,7 +18,6 @@ macro (add_example _name)
   endmacro()
   
 
-add_example(multisaw)
 add_example(normalisation_probe)
 add_example(passthrough)
 add_example(sample_and_hold)

--- a/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/wscomputer.h
+++ b/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/wscomputer.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// -----------------------------------------------------
+// NOTE: THIS HEADER IS ALSO INCLUDED BY ASSEMBLER SO
+//       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
+// -----------------------------------------------------
+
+// This header may be included by other board headers as "boards/pico.h"
+
+// pico_cmake_set PICO_PLATFORM=rp2040
+
+#ifndef _BOARDS_WSCOMPUTER_H
+#define _BOARDS_WSCOMPUTER_H
+
+// For board detection
+#define RASPBERRYPI_PICO
+
+// --- UART ---
+#ifndef PICO_DEFAULT_UART
+#define PICO_DEFAULT_UART 0
+#endif
+#ifndef PICO_DEFAULT_UART_TX_PIN
+#define PICO_DEFAULT_UART_TX_PIN 0
+#endif
+#ifndef PICO_DEFAULT_UART_RX_PIN
+#define PICO_DEFAULT_UART_RX_PIN 1
+#endif
+
+// --- LED ---
+#ifndef PICO_DEFAULT_LED_PIN
+#define PICO_DEFAULT_LED_PIN 25
+#endif
+// no PICO_DEFAULT_WS2812_PIN
+
+// --- I2C ---
+#ifndef PICO_DEFAULT_I2C
+#define PICO_DEFAULT_I2C 0
+#endif
+#ifndef PICO_DEFAULT_I2C_SDA_PIN
+#define PICO_DEFAULT_I2C_SDA_PIN 4
+#endif
+#ifndef PICO_DEFAULT_I2C_SCL_PIN
+#define PICO_DEFAULT_I2C_SCL_PIN 5
+#endif
+
+// --- SPI ---
+#ifndef PICO_DEFAULT_SPI
+#define PICO_DEFAULT_SPI 0
+#endif
+#ifndef PICO_DEFAULT_SPI_SCK_PIN
+#define PICO_DEFAULT_SPI_SCK_PIN 18
+#endif
+#ifndef PICO_DEFAULT_SPI_TX_PIN
+#define PICO_DEFAULT_SPI_TX_PIN 19
+#endif
+#ifndef PICO_DEFAULT_SPI_RX_PIN
+#define PICO_DEFAULT_SPI_RX_PIN 16
+#endif
+#ifndef PICO_DEFAULT_SPI_CSN_PIN
+#define PICO_DEFAULT_SPI_CSN_PIN 17
+#endif
+
+// --- FLASH ---
+
+#define PICO_BOOT_STAGE2_CHOOSE_W25Q080 1
+
+#ifndef PICO_FLASH_SPI_CLKDIV
+#define PICO_FLASH_SPI_CLKDIV 2
+#endif
+
+// pico_cmake_set_default PICO_FLASH_SIZE_BYTES = (2 * 1024 * 1024)
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (2 * 1024 * 1024)
+#endif
+// Drive high to force power supply into PWM mode (lower ripple on 3V3 at light loads)
+#define PICO_SMPS_MODE_PIN 23
+
+#ifndef PICO_RP2040_B0_SUPPORTED
+#define PICO_RP2040_B0_SUPPORTED 1
+#endif
+
+// The GPIO Pin used to read VBUS to determine if the device is battery powered.
+#ifndef PICO_VBUS_PIN
+#define PICO_VBUS_PIN 24
+#endif
+
+// The GPIO Pin used to monitor VSYS. Typically you would use this with ADC.
+// There is an example in adc/read_vsys in pico-examples.
+#ifndef PICO_VSYS_PIN
+#define PICO_VSYS_PIN 29
+#endif
+
+//Add delay specifically for the Music Thing WorkShop Computer
+#define PICO_XOSC_STARTUP_DELAY_MULTIPLIER 64
+
+#endif


### PR DESCRIPTION
I noticed two issues with the PicoSDK template provided-

1. An unused reference to an example called multisaw was causing cmake compile to fail

2. After build and install of any of the included examples, reseting or restarting the WSC with the newly compiled card would result in the pico not starting up at all- thanks to help from folks on Discord who identified the problem, this PR creates a custom board definition for this pico board and adds the right property to that definition: PICO_XOSC_STARTUP_DELAY_MULTIPLIER

I am not 100% sure this is the right way to do this but it works! Happy to learn if there is a better way. Let the workshop continue!