### PR TITLE
Fixing the reset issue for PicoSDK template examples in ComputerCard

### DIFF
--- a/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/CMakeLists.txt
+++ b/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/CMakeLists.txt
@@ -12,13 +12,12 @@ macro (add_example _name)
       target_link_libraries(${_name} pico_unique_id pico_stdlib hardware_dma hardware_i2c hardware_pwm hardware_adc hardware_spi)
 	  pico_add_extra_outputs(${_name})
 	  target_sources(${_name} PUBLIC ${CMAKE_CURRENT_LIST_DIR}/examples/${_name}/main.cpp)
-	  
+	  target_compile_definitions(${_name} PRIVATE PICO_XOSC_STARTUP_DELAY_MULTIPLIER=64)
 	  pico_enable_stdio_usb(${_name} 1)
     endif()
   endmacro()
   
 
-add_example(multisaw)
 add_example(normalisation_probe)
 add_example(passthrough)
 add_example(sample_and_hold)


### PR DESCRIPTION
Fixing issue described in https://github.com/TomWhitwell/Workshop_Computer/pull/3 

Thank you @chrisgjohnson for your help fixing this the right way