### PR TITLE
ComputerCard updates

### DIFF
--- a/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/LICENSE
+++ b/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/LICENSE
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2024 Chris Johnson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/README.md
+++ b/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/README.md
@@ -4,11 +4,12 @@ ComputerCard is a  [MIT licensed](https://opensource.org/license/mit) header-onl
 manages the hardware aspects of the [Music Thing Modular Workshop
 System Computer](https://www.musicthing.co.uk/workshopsystem/).
 
-ComputerCard was designed to work with the [RPi Pico SDK](https://github.com/raspberrypi/pico-sdk) but also works with the Arduino environment using the earlephilhower RP2040 board [as described below](#arduino-ide)
-
 It aims to present a very simple C++ interface for card programmers 
 to use the jacks, knobs, switch and LEDs, for programs running at
 a fixed 48kHz audio sample rate.
+
+ComputerCard was designed to work with the [RPi Pico SDK](https://github.com/raspberrypi/pico-sdk) but also works with the Arduino environment using the earlephilhower RP2040 board [as described below](#arduino-ide)
+
 
 Behind the scenes, the ComputerCard class:
 - Manages the ADC and external multiplexer to collect analogue samples from audio inputs, CV inputs, knobs and switch.

--- a/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/README.md
+++ b/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/README.md
@@ -111,7 +111,7 @@ Thanks to divmod for figuring this out and writing this section
 - Open Arduino IDE and create a new sketch and save it
 - In the Arduino IDE, select Raspberry Pi Pico as your board
 - Download ComputerCard.h file from this ComputerCard repository
-- Store this file in the directory of you sketch (there should be an .ino file with your sketch name in this directory).
+- Store this file in the directory of your sketch (there should be an .ino file with your sketch name in this directory).
 
 ### Code
 - As a start you can just copy the Sample&Hold example from the following file into your sketch (the .ino file): https://raw.githubusercontent.com/TomWhitwell/Workshop_Computer/refs/heads/main/Demonstrations%2BHelloWorlds/PicoSDK/ComputerCard/examples/sample_and_hold/main.cpp

--- a/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/README.md
+++ b/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/README.md
@@ -4,6 +4,8 @@ ComputerCard is a header-only C++ library, providing a framework that
 manages the hardware aspects of the [Music Thing Modular Workshop
 System Computer](https://www.musicthing.co.uk/workshopsystem/).
 
+ComputerCard was designed to work with the [RPi Pico SDK](https://github.com/raspberrypi/pico-sdk) but also works with the Arduino environment using the earlephilhower RP2040 board [as described below](#arduino-ide)
+
 It aims to present a very simple C++ interface for card programmers 
 to use the jacks, knobs, switch and LEDs, for programs running at
 a fixed 48kHz audio sample rate.
@@ -14,6 +16,7 @@ Behind the scenes, the ComputerCard class:
 - If enabled, determines whether jacks are connected to the six input sockets by driving the 'normalisation probe' pin and detecting its signal on the inputs.
 - Manages PWM signals for CV output and brightness control of the six LEDs.
 - Sends audio outputs to external DAC
+- Reads EEPROM calibration, if set, to for calibrated MIDI note CV outputs.
 
 
 ## Usage:
@@ -45,24 +48,87 @@ int main()
 More generally, the process is:
 1. Add `#include "ComputerCard.h"` to each cpp file that uses it. Make sure to `#define COMPUTERCARD_NOIMPL` before this include in all but one translation unit, so that the implementation is only included once.
 
-2. Derive a new class from the (abstract) ComputerCard class, representing the particular card being written.
+2. Derive a new class (such as the `SampleAndHold` class above) from the abstract ComputerCard class, representing the particular card being written.
 
 3. Do any card-specific setup in the constructor of the derived class
 
 4. Override the pure virtual `ComputerCard::ProcessSample()` method to implement the per-sample functionality required for the particular card. `ComputerCard::ProcessSample()` is called at a fixed 48kHz sample rate.
 
-5. Create an instance of the new derived class
+5. Now, create an instance of the new derived class (for example, in `main()`)
 
-6. Call the `ComputerCard::EnableNormalisationProbe()` method on it, if the normalisation probe is used.
+6. Call the `ComputerCard::EnableNormalisationProbe()` method on this instance, if the normalisation probe is used.
 
-7. Call the `ComputerCard::Run()` method on it to start audio processing. `ComputerCard::Run()` is blocking (never returns).
+7. Call the `ComputerCard::Run()` method on this instance to start audio processing. `ComputerCard::Run()` is blocking (never returns).
 
 
 ### Notes
 - Make sure execution of `ComputerCard::ProcessSample` always runs quickly enough that it has returned before the next execution begins (~20us).
 - It is anticipated that only one instance of a ComputerCard will be created.
 
-### Limitations
-As of initial version, notable omissions are:
-- no use of EEPROM calibration
-- no way to configure CV/knob smoothing filters
+### Limitations / potential future improvements
+- Only core 0 of the RP2040 is used
+    - In particular, this prevents the Pico SDK USB stdio from being used, as this code must run on core0 and interferes with the 48kHz audio callback
+- No built-in delta-sigma modulation of CV outputs, limiting CV precision of 1V/octave signals to about 7 cents
+- There is no way to configure CV/knob smoothing filters
+
+
+## [Using the RPi Pico SDK (Linux command line)](#pico-sdk)
+- Clone and install the [RPi Pico SDK](https://github.com/raspberrypi/pico-sdk)
+- Set the `PICO_SDK_PATH` environment variable to the location at with the Pico SDK is installed
+- Clone this repository
+- Create a subdirectory `build` within this repository, and `cd` into it
+- Run `cmake ..`
+- Run `make`
+- The example cards in `examples/` will be built, and all the `uf2` files all placed in the `build/` directory
+- Flash one of these `uf2` files to the Workshop System Computer in the usual way
+
+You can create your own projects using ComputerCard by
+- creating a new directory and source file in `examples/` and adding the appropriate `add_example` line to `CMakeLists.txt`.
+- or, this being a single-header library, by just copying `ComputerCard.h` into your own Pico SDK project.
+
+## [Using Visual Studio Code (with RPi Pico plugin)](#vscode)
+Disclaimer: the instructions below appear to work but are likely far from optimal (I am not a VSCode user myself)
+- Install [Visual Studio Code](https://code.visualstudio.com/) 
+- Install the [RPi Pico VSCode plugin](https://marketplace.visualstudio.com/items?itemName=raspberry-pi.raspberry-pi-pico)
+- In VSCode, click the Raspberry Pi Pico icon on the Activity Bar (by default, the bottom icon on the bar of icons going down the left side of the screen)
+- Click 'Import Project' in the 'Raspberry Pi Pico Project: Quick Access' bar that appears. Select this ComputerCard directory and continue to import the project
+- Go to the CMake icon in the Activity Bar.
+- Mouseover 'PROJECT OUTLINE' and click the 'Configure all' button (looks like a piece of paper with arrow pointing right out of it). The example projects should appear within the 'Project Outline' area.
+- Build all of these by hovering over 'PROJECT OUTLINE' again and clicking the Build All button (looks like an arrow pointing into a container of dots)
+
+
+## [Using the Arduino IDE](#arduino-ide)
+
+Thanks to divmod for figuring this out and writing this section
+
+### Installation
+
+- Install Arduino IDE: (https://www.arduino.cc/en/software)[https://www.arduino.cc/en/software]
+- Install Arduino Pico by adding it as a new board: (https://github.com/earlephilhower/arduino-pico?tab=readme-ov-file#installation)[https://github.com/earlephilhower/arduino-pico?tab=readme-ov-file#installation]
+
+### Create a new sketch
+
+- Open Arduino IDE and create a new sketch and save it
+- In the Arduino IDE, select Raspberry Pi Pico as your board
+- Download ComputerCard.h file from this ComputerCard repository
+- Store this file in the directory of you sketch (there should be an .ino file with your sketch name in this directory).
+
+### Code
+- As a start you can just copy the Sample&Hold example from the following file into your sketch (the .ino file): https://raw.githubusercontent.com/TomWhitwell/Workshop_Computer/refs/heads/main/Demonstrations%2BHelloWorlds/PicoSDK/ComputerCard/examples/sample_and_hold/main.cpp
+- Replace the `main` function with the following code:
+```
+SampleAndHold sh;
+
+void setup() {
+  sh.EnableNormalisationProbe();
+}
+
+void loop() {
+  sh.Run();
+}
+```
+- Note: The `Run()` method is blocking (never returns), and therefore takes over control from the Arduino `loop()` function. Code to be executed every sample goes in the ComputerCard `ProcessSample` function.
+- Sketch -> Export Compiled Binary
+- Your sketch directory should contain a build/rp2040.rp2040.rpipico directory (or similar) with a .uf2 file.
+  Copy this file to your Computer.
+- Done.

--- a/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/README.md
+++ b/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/README.md
@@ -136,11 +136,11 @@ void loop() {
 
 # Programming for ComputerCard
 
-The ComputerCard framework is designed to allow processing of audio signals (with bandwidths up to ~20kHz) at low latency. To do this, ComputerCard calculates audio samples individually, calling the users `ProcessSample()` function at 48kHz. The 'ProcessSample()' function for one sample must finish before the next sample is due, which restricts the user's code to a maximum of ~20μs per sample.
+ComputerCard is designed for processing of audio signals (with bandwidths up to ~20kHz) at low latency. To do this, ComputerCard calculates audio samples individually, calling the users `ProcessSample()` function at 48kHz. The 'ProcessSample()' function for one sample must finish before the next sample is due, meaning that the user's code for each sample must execute in ~20μs.
 
-ComputerCard can of course be used for programs using pulse/CV signals only, and these will benefit from the low latency of ComputerCard. But, the fixed 48kHz clock used by ComputerCard means that these programs still need to abide by the same stringent audio timing requirements.
+ComputerCard can of course be used for programs using pulse/CV signals only - but, the fixed 48kHz sample rate means that these programs still need to abide by the same stringent audio timing requirements.
 
-The RP2040 microcontroller in the Computer is a 133MHz dual-core chip, with hardware multiplier but no hardware floating point support. Given these specifications, the ~20μs-per-sample time limit has several consequences:
+The RP2040 microcontroller in the Computer is a 133MHz dual-core chip, with hardware multiplier but no hardware floating point support. Given these specifications, the ~20μs-per-sample limit has several consequences:
 
 1. most calculations must be done with integers, rather than floating point.
 2. relatively expensive calculations must be split between `ProcessSample` calls to ensure than no one call goes above the maximum duration.
@@ -153,7 +153,7 @@ We'll discuss each of these below
 
 Native integer calculations on the RP2040 - that is, addition, subtraction and multiplication of at most 32-bit numbers - are around [35 times faster](https://forums.raspberrypi.com/viewtopic.php?t=308794#p1848188) than the software-emulated floating point equivalents.
 
-At the specified 133MHz clock rate, floating point operations take around 500ns, allowing at most 40 (at likely rather fewer) per sample. Even a single call to more complicated floating point functions such as `sin` is too expensive to run every sample. For this reason, ComputerCard does not use floating-point variables.
+At the specified 133MHz clock rate, floating point operations take around 500ns, allowing at most 40 (in practice, likely rather fewer) per sample. Even a single call to more complicated floating point functions such as `sin` is too expensive to run every sample. For this reason, ComputerCard does not use floating-point variables.
 
 Since the Computer uses a 12-bit DAC, the approach I have taken instead is to use signed 16-bit integers to store signals, but usually signed 32-bit integers (`int32_t`, as defined in the `cstdint` header) to process them. The hardware integer multiply on the RP2040 makes many such operations very efficient. 
 

--- a/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/README.md
+++ b/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/README.md
@@ -15,12 +15,12 @@ Behind the scenes, the ComputerCard class:
 - Applies smoothing, some simple hysteresis, and range extension to knobs and CV, to provide relatively low-noise values that span the whole range (-2048 to 2047). Knob/CV values are updated every audio frame.
 - If enabled, determines whether jacks are connected to the six input sockets by driving the 'normalisation probe' pin and detecting its signal on the inputs.
 - Manages PWM signals for CV output and brightness control of the six LEDs.
-- Sends audio outputs to external DAC
-- Reads EEPROM calibration, if set, to for calibrated MIDI note CV outputs.
+- Sends audio outputs to external DAC.
+- Reads EEPROM calibration, if set, for calibrated MIDI note CV outputs.
 
 
 ## Usage:
-Basic usage is intended to be extremely simple: for example, here is complete code for a Sample and Hold card:
+Basic usage is intended to be extremely simple. For example, here is complete code for a Sample and Hold card:
 
 ```c++
 #include "ComputerCard.h"
@@ -29,17 +29,17 @@ Basic usage is intended to be extremely simple: for example, here is complete co
 class SampleAndHold : public ComputerCard
 {
 public:
-	virtual void ProcessSample() // executed every sample at 48kHz
+	virtual void ProcessSample() // executed every sample, at 48kHz
 	{
-    	// Update audio out 1 with value from audio in 1,
-        // only if rising edge seen on pulse 1 input
+		// Update audio out 1 with value from audio in 1,
+		// only if rising edge seen on pulse 1 input
 		if (PulseIn1RisingEdge()) AudioOut1(AudioIn1());
 	}
 };
 
 int main()
 {
-    // Create and run our new Sample and Hold
+	// Create and run our new Sample and Hold
 	SampleAndHold sh;
 	sh.Run();
 }
@@ -62,7 +62,7 @@ More generally, the process is:
 
 
 ### Notes
-- Make sure execution of `ComputerCard::ProcessSample` always runs quickly enough that it has returned before the next execution begins (~20μs). (See the [guidance below](#programming) on achieving this)
+- Make sure execution of `ComputerCard::ProcessSample` always runs quickly enough that it has returned before the next execution begins (1/48kHz = ~20μs). (See the [guidance below](#programming) on achieving this)
 - It is anticipated that only one instance of a ComputerCard will be created.
 
 ### Limitations / potential future improvements
@@ -70,6 +70,7 @@ More generally, the process is:
     - In particular, this prevents the Pico SDK USB stdio from being used, as this code must run on core0 and interferes with the 48kHz audio callback
 - No built-in delta-sigma modulation of CV outputs, limiting CV precision of 1V/octave signals to about 7 cents
 - There is no way to configure CV/knob smoothing filters.
+- There is no way to change the sample rate
 
 ## [Using the RPi Pico SDK (Linux command line)](#pico-sdk)
 - Clone and install the [RPi Pico SDK](https://github.com/raspberrypi/pico-sdk)


### PR DESCRIPTION
Some minor updates to ComputerCard
- New MIDI note to calibrated 1V/oct CV out functions
- Fix bug where audio inputs and outputs were both inverted
- More detailed readme

@dessertplanet  the readme now includes a description of how I got it compiling on VSCode, based on your success with this - but I don't really know VS Code so let me know if this is misleading
