### PR TITLE
Requesting card 38 for Od module - Lorenz attractor chaotic CV

### DIFF
--- a/releases/38_od/README.md
+++ b/releases/38_od/README.md
@@ -1,0 +1,17 @@
+# Od
+
+Od is a program for the Music Thing Modular Workshop System Computer
+module that simulates the Lorenz system in order to produce loop-able 
+control voltage and pulse signals that display sensitivity to initial conditions.
+
+This project is developed and documented in
+[a separate repo](https://github.com/MJLMills/mtmws_od), issues and feature 
+requests can be raised there, or by finding the author via the Workshop System 
+Discord (@sneddo_trainer). The majority of the core module code is in the 
+[pyworkshopsystem](https://github.com/MJLMills/pyworkshopsystem) repo, a
+reusable package for building programs for the Computer module with 
+MicroPython.
+
+A .uf2 file will be provided once features are finalized and tested and all 
+packaging is complete. For now it is possible to try the module out using the 
+provided main.py file (which contains the complete module code).

--- a/releases/README.md
+++ b/releases/README.md
@@ -12,6 +12,7 @@
 | 24_crafted_volts | Manually set control voltages (CV) with the input knobs and switch. It also attenuverts (attenuates and inverts) incoming voltages. | (see source repo) | Rust (Embassy framework) | Brian Dorsey | Released |
 | 28_eighties_bass | Bass-oriented complete monosynth voice consisting of five detuned saw wave oscillators with mixable white noise and adjustable resonant filter. | 0.1 | arduino-pico core and Mozzi 2 library | @todbot / Tod Kurt | Functional but WIP |
 | 30_cirpy_wavetable | Wavetable oscillator that using wavetables from Plaits, Braids, and Microwave, | 0.1 | Circuit Python | @todbot / Tod Kurt | Functional but WIP |
+| 38_od              | Loopable chaotic Lorenz attractor trajectories and zero-crossings as CV and pulses, with sensitivity to initial conditions.                                             | 0.0               | MicroPython                                          | M. John Mills      | Functional but WIP (no .uf2 yet) |
 | 42_backyard_rain | Nature soundscape audio. A cozy rain ambience mix for background listening. You control the intensity. This card plays rain ambience which was recorded in my backyard. | (see source repo) | Rust (Embassy framework) | Brian Dorsey | Released |
 | 77_Placeholder | Reserved for secret project | 0.0 | None | None | None |
 | 78_Talker | Proof of concept speech synthesizer, based on TalkiePCM, inspired by 1970s LPC speech synths. | 0.1 | C (RPi Pico SDK) | Chris Johnson | Proof of concept |


### PR DESCRIPTION
This PR requests card number 38 for the Od module, developed in https://github.com/MJLMills/mtmws_od. The README has further details. A .uf2 is not yet provided but is imminent, if you want to hold off merging this PR until it exists that's fine, I have a couple of interface features to add before packaging.

Current documentation is here: https://github.com/MJLMills/mtmws_od/blob/main/docs/od.pdf

Thanks!
______
Od is a program for the Music Thing Modular Workshop System Computer
module that simulates the Lorenz system in order to produce loop-able 
control voltage and pulse signals that display sensitivity to initial conditions.
