### PR TITLE
Add info.yaml for Od (#38)

### DIFF
--- a/releases/38_od/info.yaml
+++ b/releases/38_od/info.yaml
@@ -1,0 +1,5 @@
+Description: Loopable chaotic Lorenz attractor trajectories and zero-crossings as CV and pulses, with sensitivity to initial conditions.
+Language: MicroPython
+Creator:  'M. John Mills'
+Version: 0.0
+Status: Functional but WIP (no .uf2)


### PR DESCRIPTION
This PR adds the missing info.yaml file for card #38 (Od).
Corrects an error where the README.md was edited directly in a previous PR.