### PR TITLE
ComputerCard: USB host detection and USB MIDI host

### DIFF
--- a/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/CMakeLists.txt
+++ b/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/CMakeLists.txt
@@ -43,3 +43,17 @@ add_example(sine_wave_lookup)
 add_example(sine_wave_float)
 
 
+add_example(usb_detect)
+
+add_example(midi_host)
+target_sources(midi_host PUBLIC ${CMAKE_CURRENT_LIST_DIR}/examples/midi_host/usb_midi_host.c  ${CMAKE_CURRENT_LIST_DIR}/examples/midi_host/usb_midi_host_app_driver.c)
+target_link_libraries(midi_host pico_multicore tinyusb_host tinyusb_board  )
+
+
+add_example(midi_device_host)
+target_link_libraries(midi_device_host pico_multicore tinyusb_host tinyusb_board  tinyusb_device  )
+target_sources(midi_device_host PUBLIC
+  ${CMAKE_CURRENT_LIST_DIR}/examples/midi_device_host/usb_midi_host.c
+  ${CMAKE_CURRENT_LIST_DIR}/examples/midi_device_host/usb_midi_host_app_driver.c
+  ${CMAKE_CURRENT_LIST_DIR}/examples/midi_device_host/usb_descriptors.c
+)

--- a/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/LICENSE
+++ b/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/LICENSE
@@ -1,9 +1,19 @@
 MIT License
 
-Copyright (c) 2024 Chris Johnson
+Copyright (c) 2024-5 Chris Johnson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+
+
+
+
+`midi_host` and `midi_device_host` examples use MIT-licensed code (`usb_midi_host.c`, `usb_midi_host.h` and `usb_midi_host_app_driver.c`) from https://github.com/rppicomidi/usb_midi_host
+
+Copyright (c) 2023 rppicomidi

--- a/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/examples/midi_device_host/main.cpp
+++ b/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/examples/midi_device_host/main.cpp
@@ -1,0 +1,301 @@
+#include "ComputerCard.h"
+
+#include "pico/multicore.h"
+#include "bsp/board.h"
+#include "tusb.h"
+#include "usb_midi_host.h"
+
+// Minimal MIDI message reading struct
+struct MIDIMessage
+{
+	// Parse a MIDI message from the raw packet data
+	MIDIMessage(uint8_t* packet)
+	{
+		channel = packet[0]&0x0F;
+		command = static_cast<Command>(packet[0] & 0xF0);
+		switch (packet[0]&0xF0)
+		{
+		case Command::NoteOn: // two separate data bytes
+		case Command::NoteOff:
+		case Command::Aftertouch:
+		case Command::CC:
+			note = packet[1];
+			velocity = packet[2];
+			break;
+			
+		case Command::PatchChange: // single data bytes
+			instrument = packet[1];
+			break;
+			
+		case Command::PitchBend: // pitch bend combines msb/lsb
+			pitchbend = packet[1] + (packet[2]<<7) - 8192;
+			break;
+			
+		default:
+			command = Command::Unknown;
+			break;
+		}
+	}
+	
+	enum Command {Unknown = 0x00, NoteOn = 0x90, NoteOff = 0x80,
+		PitchBend = 0xE0, Aftertouch = 0xA0, CC = 0xB0,	PatchChange = 0xC0};
+	Command command;
+	uint8_t channel;
+	union // Store MIDI data bytes in two-byte union
+	{
+		struct
+		{
+			union // data byte 1
+			{
+				uint8_t note; // note on/off/aftertouch
+				uint8_t cc; // CC
+				uint8_t instrument; // patch change
+			};
+			union // data byte 2
+			{
+				uint8_t velocity; // note on/off
+				uint8_t touch; // aftertouch
+				uint8_t value; // CC 
+			};
+		};
+		int16_t pitchbend;
+	};
+};
+
+class MIDIDeviceHost : public ComputerCard
+{
+public:
+	MIDIDeviceHost()
+	{
+		midi_dev_addr = 0;
+		device_connected = 0;
+		
+		counter = 0;
+		powerState = Unsupported;
+		
+		// Start the second core
+		multicore_launch_core1(core1);
+	}
+
+	// Boilerplate to call member function as second core
+	static void core1()
+	{
+		((MIDIDeviceHost *)ThisPtr())->USBCore();
+	}
+
+
+	// Send alternate note-on and note-off messages
+	void SendNextNote(bool isHost)
+	{
+		static uint8_t noteOn[3] = {0x90, 0x5f, 0x7f};
+		static uint8_t noteOff[3] = {0x80, 0x5f, 0x00};
+		static bool noteOnNext = true;
+
+		// Transmit the note message on the highest cable number
+		uint8_t cable = tuh_midih_get_num_tx_cables(midi_dev_addr) - 1;
+
+
+		// Toggle between sending note-on and note-off messages
+		if (noteOnNext)
+		{
+			if (isHost)
+			{
+				tuh_midi_stream_write(midi_dev_addr, cable, noteOn, sizeof(noteOn));
+			}
+			else
+			{
+				tud_midi_stream_write(0, noteOn, sizeof(noteOn));
+			}
+		}
+		else
+		{
+			if (isHost)
+			{
+				tuh_midi_stream_write(midi_dev_addr, cable, noteOff, sizeof(noteOff));
+			}
+			else
+			{
+				tud_midi_stream_write(0, noteOff, sizeof(noteOff));
+			}
+		}
+
+		// Toggle between note on / note off
+		noteOnNext = !noteOnNext;
+	}
+
+	
+	// Code for second RP2040 core, blocking
+	// Handles MIDI in/out messages
+	void USBCore()
+	{
+		uint8_t packet[32];
+
+		powerState = USBPowerState();
+
+		// On reboot, choose between USB device or USB host mode
+		if (powerState == UFP)
+		{
+			tud_init(TUD_OPT_RHPORT);
+		}
+		else if (powerState == DFP)
+		{
+			tuh_init(TUD_OPT_RHPORT);
+		}
+
+		board_init();
+		
+		while (1)
+		{
+			if (powerState == UFP) // Computer is USB device
+			{
+				tud_task();
+				while (tud_midi_available())
+				{
+					// Read and discard MIDI input
+					tud_midi_stream_read(packet, sizeof(packet));
+			
+				}
+				
+				if (counter >= 20000)
+				{
+					SendNextNote(false);
+					counter -= 20000;
+				}
+			}
+			else if (powerState == DFP) // Computer is USB host
+			{
+				tuh_task();
+		
+				bool connected = midi_dev_addr != 0 && tuh_midi_configured(midi_dev_addr);
+
+				// device must be attached and have at least one endpoint ready to receive a message
+				if (connected && tuh_midih_get_num_tx_cables(midi_dev_addr) >= 1)
+				{
+
+					if (counter >= 20000)
+					{
+						SendNextNote(true);
+						counter -= 20000;
+					}
+
+					// Send a USB packet immediately (even though in this case,
+					// we are not close to the 64-byte maximum payload)
+					tuh_midi_stream_flush(midi_dev_addr);
+				}
+			}
+		}
+
+	}
+
+	
+	// 48kHz audio processing function
+	virtual void ProcessSample()
+	{
+		// No audio I/O, so just flash an LED
+		// to indicate that the card is running
+		static int32_t frame=0;
+
+		// Top two LEDS held on if we can't determine USB power state
+		if (powerState == Unsupported)
+		{
+			LedOn(0);
+			LedOn(1);
+		
+		}
+		else // otherwise, flash LED 5 if DFP, LED 4 if UFP
+		{
+			LedOff(0);
+			LedOff(1);
+			int activeLED = (powerState==DFP)?5:4;
+			int inactiveLED = (powerState==DFP)?4:5;
+			LedOn(activeLED, (frame>>13)&1);
+			LedOff(inactiveLED);
+		}
+		frame++;
+
+		
+		// Counter is reset by other core
+		if (counter <= 30000)
+			counter++;
+	}
+
+	
+	static uint8_t device_connected;
+	static uint8_t midi_dev_addr;
+	
+private:
+	USBPowerState_t powerState;
+	volatile uint32_t counter;
+};
+
+uint8_t MIDIDeviceHost::device_connected;
+uint8_t MIDIDeviceHost::midi_dev_addr;
+
+
+// Four callback functions that rppicomidi/usb_midi_host uses
+
+void tuh_midi_mount_cb(uint8_t dev_addr, uint8_t in_ep, uint8_t out_ep, uint8_t num_cables_rx, uint16_t num_cables_tx)
+{
+	(void)in_ep; (void)out_ep; (void)num_cables_rx; (void)num_cables_tx; // avoid unused variable warnings
+
+	
+	if (MIDIDeviceHost::midi_dev_addr == 0)
+	{
+		MIDIDeviceHost::midi_dev_addr = dev_addr;
+		MIDIDeviceHost::device_connected = 1;
+	}
+}
+
+void tuh_midi_umount_cb(uint8_t dev_addr, uint8_t instance)
+{
+	(void)instance;
+	
+	if (dev_addr == MIDIDeviceHost::midi_dev_addr)
+	{
+		MIDIDeviceHost::midi_dev_addr = 0;
+		MIDIDeviceHost::device_connected = 0;
+	}
+}
+
+void tuh_midi_rx_cb(uint8_t dev_addr, uint32_t num_packets)
+{
+	if (MIDIDeviceHost::midi_dev_addr != dev_addr)
+		return;
+
+	if (num_packets == 0)
+		return;
+	
+	uint8_t cable_num;
+	uint8_t buffer[48];
+	while (1)
+	{
+		uint32_t bytes_read = tuh_midi_stream_read(dev_addr, &cable_num, buffer, sizeof(buffer));
+
+		if (bytes_read == 0)
+			return;
+		
+		for (uint32_t idx = 0; idx < bytes_read; idx++)
+		{
+			//buffer[idx]
+		}
+	}
+
+}
+
+void tuh_midi_tx_cb(uint8_t dev_addr)
+{
+    (void)dev_addr;
+}
+
+
+
+
+
+
+int main()
+{
+	MIDIDeviceHost mdh;
+	mdh.Run();
+}
+
+  

--- a/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/examples/midi_device_host/tusb_config.h
+++ b/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/examples/midi_device_host/tusb_config.h
@@ -1,0 +1,107 @@
+
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ha Thach (tinyusb.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#ifndef _TUSB_CONFIG_H_
+#define _TUSB_CONFIG_H_
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+//--------------------------------------------------------------------
+// COMMON CONFIGURATION
+//--------------------------------------------------------------------
+
+// defined by compiler flags for flexibility
+#ifndef CFG_TUSB_MCU
+  #error CFG_TUSB_MCU must be defined
+#endif
+
+#define CFG_TUSB_RHPORT0_MODE       OPT_MODE_HOST | OPT_MODE_DEVICE
+
+
+#ifndef CFG_TUSB_OS
+#define CFG_TUSB_OS                 OPT_OS_NONE
+#endif
+
+#ifndef CFG_TUSB_MEM_SECTION
+#define CFG_TUSB_MEM_SECTION
+#endif
+
+#ifndef CFG_TUSB_MEM_ALIGN
+#define CFG_TUSB_MEM_ALIGN          __attribute__ ((aligned(4)))
+#endif
+
+
+
+
+//----------------------------
+
+
+#ifndef CFG_TUD_ENDPOINT0_SIZE
+#define CFG_TUD_ENDPOINT0_SIZE    64
+#endif
+
+//------------- CLASS -------------//
+#define CFG_TUD_HID               0
+#define CFG_TUD_CDC               0
+#define CFG_TUD_MSC               0
+#define CFG_TUD_MIDI              1
+#define CFG_TUD_VENDOR            0
+
+// MIDI FIFO size of TX and RX
+#define CFG_TUD_MIDI_RX_BUFSIZE   (TUD_OPT_HIGH_SPEED ? 512 : 64)
+#define CFG_TUD_MIDI_TX_BUFSIZE   (TUD_OPT_HIGH_SPEED ? 512 : 64)
+
+
+
+	 
+//--------------------------------------------------------------------
+// CONFIGURATION
+//--------------------------------------------------------------------
+
+// Size of buffer to hold descriptors and other data used for enumeration
+#define CFG_TUH_ENUMERATION_BUFSIZE 256
+
+#define CFG_TUH_HUB                 1 // Enable USB hubs
+#define CFG_TUH_CDC                 0
+#define CFG_TUH_HID                 0 // typical keyboard + mouse device can have 3-4 HID interfaces
+//NOTE: Do note #define CFG_TUH_MIDI 1 to enable MIDI Host. A code fragment in usbh.c that breaks the build if you do that
+#define CFG_TUH_MSC                 1
+#define CFG_TUH_VENDOR              0
+
+// max device support (excluding hub device)
+#define CFG_TUH_DEVICE_MAX          (CFG_TUH_HUB ? 4 : 1) // hub typically has 4 ports
+
+// MIDI Host string support
+#define CFG_MIDI_HOST_DEVSTRINGS 1
+
+	 
+#ifdef __cplusplus
+ }
+#endif
+
+#endif /* _TUSB_CONFIG_H_ */

--- a/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/examples/midi_device_host/usb_descriptors.c
+++ b/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/examples/midi_device_host/usb_descriptors.c
@@ -1,0 +1,134 @@
+#include "tusb.h"
+
+#define USB_PID   0x000A // Pi Pick CDC
+#define USB_VID   0x2E8A // Raspberry Pi
+#define USB_BCD   0x0200
+
+// Device Descriptor
+tusb_desc_device_t const desc_device =
+{
+    .bLength            = sizeof(tusb_desc_device_t),
+    .bDescriptorType    = TUSB_DESC_DEVICE,
+    .bcdUSB             = USB_BCD,
+    .bDeviceClass       = 0x00,
+    .bDeviceSubClass    = 0x00,
+    .bDeviceProtocol    = 0x00,
+    .bMaxPacketSize0    = CFG_TUD_ENDPOINT0_SIZE,
+
+    .idVendor           = USB_VID,
+    .idProduct          = USB_PID,
+    .bcdDevice          = 0x0100,
+
+    .iManufacturer      = 0x01,
+    .iProduct           = 0x02,
+    .iSerialNumber      = 0x03,
+
+    .bNumConfigurations = 0x01
+};
+
+uint8_t const * tud_descriptor_device_cb(void)
+{
+	return (uint8_t const *) &desc_device;
+}
+
+// Configuration descriptor
+enum
+{
+	ITF_NUM_MIDI = 0,
+	ITF_NUM_MIDI_STREAMING,
+	ITF_NUM_TOTAL
+};
+
+#define CONFIG_TOTAL_LEN  (TUD_CONFIG_DESC_LEN + TUD_MIDI_DESC_LEN)
+
+// Endpoint number
+#define EPNUM_MIDI   0x01
+
+uint8_t const desc_fs_configuration[] =
+{
+	// Config number, interface count, string index, total length, attribute, power in mA
+	TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, 0x00, 100),
+
+	// Interface number, string index, EP Out & EP In address, EP size
+	TUD_MIDI_DESCRIPTOR(ITF_NUM_MIDI, 0, EPNUM_MIDI, 0x80 | EPNUM_MIDI, 64)
+};
+
+#if TUD_OPT_HIGH_SPEED
+uint8_t const desc_hs_configuration[] =
+{
+	// Config number, interface count, string index, total length, attribute, power in mA
+	TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, 0x00, 100),
+
+	// Interface number, string index, EP Out & EP In address, EP size
+	TUD_MIDI_DESCRIPTOR(ITF_NUM_MIDI, 0, EPNUM_MIDI, 0x80 | EPNUM_MIDI, 512)
+};
+#endif
+
+// Invoked when received GET CONFIGURATION DESCRIPTOR
+// Application return pointer to descriptor
+// Descriptor contents must exist long enough for transfer to complete
+uint8_t const * tud_descriptor_configuration_cb(uint8_t index)
+{
+	(void) index; // for multiple configurations
+
+#if TUD_OPT_HIGH_SPEED
+	// Although we are highspeed, host may be fullspeed.
+	return (tud_speed_get() == TUSB_SPEED_HIGH) ?  desc_hs_configuration : desc_fs_configuration;
+#else
+	return desc_fs_configuration;
+#endif
+}
+
+//--------------------------------------------------------------------+
+// String Descriptors
+//--------------------------------------------------------------------+
+
+// array of pointer to string descriptors
+char const* string_desc_arr [] =
+{
+	(const char[]) { 0x09, 0x04 }, // 0: is supported language is English (0x0409)
+	"Music Thing",                     // 1: Manufacturer
+	"MTMComputer", // 2: Product
+	"123456",                      // 3: Serials, should use chip ID
+};
+
+static uint16_t _desc_str[32];
+
+// Invoked when received GET STRING DESCRIPTOR request
+// Application return pointer to descriptor, whose contents must exist long enough for transfer to complete
+uint16_t const* tud_descriptor_string_cb(uint8_t index, uint16_t langid)
+{
+	(void) langid;
+
+	uint8_t chr_count;
+
+	if (index == 0)
+	{
+		memcpy(&_desc_str[1], string_desc_arr[0], 2);
+		chr_count = 1;
+	}
+	else
+	{
+		// Note: the 0xEE index string is a Microsoft OS 1.0 Descriptors.
+		// https://docs.microsoft.com/en-us/windows-hardware/drivers/usbcon/microsoft-defined-usb-descriptors
+
+		if ( !(index < sizeof(string_desc_arr)/sizeof(string_desc_arr[0])) ) return NULL;
+
+		const char* str = string_desc_arr[index];
+
+		// Cap at max char
+		chr_count = strlen(str);
+		if ( chr_count > 31 ) chr_count = 31;
+
+		// Convert ASCII string into UTF-16
+		for(uint8_t i=0; i<chr_count; i++)
+		{
+			_desc_str[1+i] = str[i];
+		}
+	}
+
+	// first byte is length (including header), second byte is string type
+	_desc_str[0] = (TUSB_DESC_STRING << 8 ) | (2*chr_count + 2);
+
+	return _desc_str;
+}

--- a/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/examples/midi_device_host/usb_midi_host.c
+++ b/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/examples/midi_device_host/usb_midi_host.c
@@ -1,0 +1,1034 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 rppicomidi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include "tusb_option.h"
+
+#if (TUSB_OPT_HOST_ENABLED)
+
+#include "host/usbh.h"
+#include "host/usbh_pvt.h"
+
+#include "usb_midi_host.h"
+#include <stdlib.h>
+//--------------------------------------------------------------------+
+// MACRO CONSTANT TYPEDEF
+//--------------------------------------------------------------------+
+#ifndef CFG_TUH_MAX_CABLES
+  #define CFG_TUH_MAX_CABLES 16
+#endif
+#ifndef CFG_TUH_MIDI_RX_BUFSIZE
+  #define CFG_TUH_MIDI_RX_BUFSIZE USBH_EPSIZE_BULK_MAX
+#endif
+#ifndef CFG_TUH_MIDI_TX_BUFSIZE
+  #define CFG_TUH_MIDI_TX_BUFSIZE USBH_EPSIZE_BULK_MAX
+#endif
+#ifndef CFG_TUH_MIDI_EP_BUFSIZE
+  #define CFG_TUH_MIDI_EP_BUFSIZE USBH_EPSIZE_BULK_MAX
+#endif
+
+#define MIDI_MAX_DATA_VAL 0x7f
+static struct midih_limits_s {
+    size_t midi_rx_buf;
+    size_t midi_tx_buf;
+    uint8_t max_cables;
+} midih_limits = {CFG_TUH_MIDI_RX_BUFSIZE, CFG_TUH_MIDI_TX_BUFSIZE, CFG_TUH_MAX_CABLES};
+
+// This descriptor follows the standard bulk data endpoint descriptor
+typedef struct
+{
+  uint8_t bLength            ; ///< Size of this descriptor in bytes (4+bNumEmbMIDIJack)
+  uint8_t bDescriptorType    ; ///< Descriptor Type, must be CS_ENDPOINT
+  uint8_t bDescriptorSubType ; ///< Descriptor SubType, must be MS_GENERAL
+  uint8_t bNumEmbMIDIJack;   ; ///< Number of embedded MIDI jacks associated with this endpoint
+  uint8_t baAssocJackID[];   ; ///< A list of associated jacks
+} midi_cs_desc_endpoint_t;
+
+typedef struct
+{
+  uint8_t buffer[4];
+  uint8_t index;
+  uint8_t total;
+}midi_stream_t;
+
+typedef struct
+{
+  uint8_t dev_addr;
+  uint8_t itf_num;
+
+  uint8_t ep_in;          // IN endpoint address
+  uint8_t ep_out;         // OUT endpoint address
+  uint16_t ep_in_max;     // min( midih_limits.midi_rx_buf, wMaxPacketSize of the IN endpoint)
+  uint16_t ep_out_max;    //  min( midih_limits.midi_tx_buf, wMaxPacketSize of the OUT endpoint)
+
+  uint8_t num_cables_rx;  // IN endpoint CS descriptor bNumEmbMIDIJack value
+  uint8_t num_cables_tx;  // OUT endpoint CS descriptor bNumEmbMIDIJack value
+
+  // For Stream read()/write() API
+  // Messages are always 4 bytes long, queue them for reading and writing so the
+  // callers can use the Stream interface with single-byte read/write calls.
+  midi_stream_t *stream_write;
+  midi_stream_t stream_read;
+
+  /*------------- From this point, data is not cleared by bus reset -------------*/
+  // Endpoint FIFOs
+  tu_fifo_t rx_ff;
+  tu_fifo_t tx_ff;
+ 
+
+  uint8_t *rx_ff_buf;
+  uint8_t *tx_ff_buf;
+
+  #if CFG_FIFO_MUTEX
+  osal_mutex_def_t rx_ff_mutex;
+  osal_mutex_def_t tx_ff_mutex;
+  #endif
+
+  // Endpoint Transfer buffer
+  CFG_TUSB_MEM_ALIGN uint8_t epout_buf[CFG_TUH_MIDI_EP_BUFSIZE];
+  CFG_TUSB_MEM_ALIGN uint8_t epin_buf[CFG_TUH_MIDI_EP_BUFSIZE];
+
+  bool configured;
+  // Track the transfer result in the xfer_cb function
+  // If the result is not XFER_RESULT_SUCCESS, block
+  // midih_flush() and do not restart IN polling.
+  // The user will need to unplug and re-plug the device
+  xfer_result_t last_xfer_result;
+#if CFG_MIDI_HOST_DEVSTRINGS
+#define MAX_STRING_INDICES 32
+  uint8_t all_string_indices[MAX_STRING_INDICES];
+  uint8_t num_string_indices;
+#define MAX_IN_JACKS 8
+#define MAX_OUT_JACKS 8
+  struct {
+    uint8_t jack_id;
+    uint8_t jack_type;
+    uint8_t string_index;
+  } in_jack_info[MAX_IN_JACKS];
+  uint8_t next_in_jack;
+  struct {
+    uint8_t jack_id;
+    uint8_t jack_type;
+    uint8_t num_source_ids;
+    uint8_t source_ids[MAX_IN_JACKS/4];
+    uint8_t string_index;
+  } out_jack_info[MAX_OUT_JACKS];
+  uint8_t next_out_jack;
+  uint8_t ep_in_associated_jacks[MAX_OUT_JACKS/2];
+  uint8_t ep_out_associated_jacks[MAX_IN_JACKS/2];
+#endif
+}midih_interface_t;
+
+static midih_interface_t _midi_host[CFG_TUH_DEVICE_MAX];
+
+static midih_interface_t *get_midi_host(uint8_t dev_addr)
+{
+  TU_VERIFY(dev_addr >0 && dev_addr <= CFG_TUH_DEVICE_MAX);
+  return (_midi_host + dev_addr - 1);
+}
+
+//------------- Internal prototypes -------------//
+static uint32_t write_flush(uint8_t dev_addr, midih_interface_t* midi);
+
+static void midih_freeall(void)
+{
+  // free memory allocated by midih_init()
+  for (int inst = 0; inst < CFG_TUH_DEVICE_MAX; inst++)
+  {
+    midih_interface_t *p_midi_host = &_midi_host[inst];
+    if (p_midi_host->rx_ff_buf != NULL)
+    {
+      free (p_midi_host->rx_ff_buf);
+      p_midi_host->rx_ff_buf = NULL;
+    }
+    if (p_midi_host->tx_ff_buf != NULL)
+    {
+      free (p_midi_host->tx_ff_buf);
+      p_midi_host->tx_ff_buf = NULL;
+    }
+    if (p_midi_host->stream_write != NULL)
+    {
+      free(p_midi_host->stream_write);
+      p_midi_host->stream_write = NULL;
+    }
+  }
+}
+
+//--------------------------------------------------------------------+
+// USBH API
+//--------------------------------------------------------------------+
+void tuh_midih_define_limits(size_t midi_rx_buffer_bytes, size_t midi_tx_buffer_bytes, uint8_t max_cables)
+{
+  // prevent memory leak in case midih_init() was called before this function
+  midih_freeall();
+  midih_limits.midi_rx_buf = midi_rx_buffer_bytes;
+  midih_limits.midi_tx_buf = midi_tx_buffer_bytes;
+  midih_limits.max_cables = max_cables;
+}
+
+bool midih_init(void)
+{
+  tu_memclr(&_midi_host, sizeof(_midi_host));
+  // config fifos
+  for (int inst = 0; inst < CFG_TUH_DEVICE_MAX; inst++)
+  {
+    midih_interface_t *p_midi_host = &_midi_host[inst];
+    p_midi_host->rx_ff_buf = malloc(midih_limits.midi_rx_buf);
+    p_midi_host->tx_ff_buf = malloc(midih_limits.midi_tx_buf);
+    p_midi_host->stream_write = malloc(midih_limits.max_cables * sizeof(midi_stream_t));
+    TU_ASSERT((p_midi_host->rx_ff_buf != NULL && p_midi_host->tx_ff_buf != NULL && p_midi_host->stream_write != NULL), 0);
+    tu_memclr(p_midi_host->stream_write, sizeof(*(p_midi_host->stream_write))*midih_limits.max_cables);
+    tu_fifo_config(&p_midi_host->rx_ff, p_midi_host->rx_ff_buf, midih_limits.midi_rx_buf, 1, false); // true, true
+    tu_fifo_config(&p_midi_host->tx_ff, p_midi_host->tx_ff_buf, midih_limits.midi_tx_buf, 1, false); // OBVS.
+
+  #if CFG_FIFO_MUTEX
+    tu_fifo_config_mutex(&p_midi_host->rx_ff, NULL, osal_mutex_create(&p_midi_host->rx_ff_mutex));
+    tu_fifo_config_mutex(&p_midi_host->tx_ff, osal_mutex_create(&p_midi_host->tx_ff_mutex), NULL);
+  #endif
+  }
+  return true;
+}
+
+bool midih_deinit()
+{
+  midih_freeall();
+  return true;
+}
+bool midih_xfer_cb(uint8_t dev_addr, uint8_t ep_addr, xfer_result_t result, uint32_t xferred_bytes)
+{
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  TU_VERIFY(p_midi_host != NULL);
+  p_midi_host->last_xfer_result = result;
+  if (result == XFER_RESULT_FAILED) {
+    TU_LOG2("MIDIH xfer result failed\r\n");
+    return false;
+  }
+  TU_ASSERT(result == XFER_RESULT_SUCCESS);
+
+  if ( ep_addr == p_midi_host->ep_in)
+  {
+    // receive new data if available
+    uint32_t packets_queued = 0;
+    if (xferred_bytes)
+    {
+      // put in the RX FIFO only non-zero MIDI IN 4-byte packets
+      uint8_t* buf = p_midi_host->epin_buf;
+      uint32_t npackets = xferred_bytes / 4;
+      uint32_t packet_num;
+      for (packet_num = 0; packet_num < npackets; packet_num++)
+      {
+        // some devices send back all zero packets even if there is no data ready
+        uint32_t packet = (uint32_t)((*buf)<<24) | ((uint32_t)(*(buf+1))<<16) | ((uint32_t)(*(buf+2))<<8) | ((uint32_t)(*(buf+3)));
+        if (packet != 0)
+        {
+          tu_fifo_write_n(&p_midi_host->rx_ff, buf, 4);
+          ++packets_queued;
+          TU_LOG3("MIDI RX=%08lx\r\n", packet);
+        }
+        buf += 4;
+      }
+      // invoke receive callback if available
+      if (tuh_midi_rx_cb && packets_queued)
+      {
+        tuh_midi_rx_cb(dev_addr, packets_queued);
+      }
+    }
+
+    TU_LOG2("Requesting poll IN endpoint %d\r\n", p_midi_host->ep_in);
+    TU_ASSERT(usbh_edpt_xfer(p_midi_host->dev_addr, p_midi_host->ep_in, p_midi_host->epin_buf, p_midi_host->ep_in_max), 0);
+  }
+  else if ( ep_addr == p_midi_host->ep_out )
+  {
+    if (0 == write_flush(dev_addr, p_midi_host))
+    {
+      // If there is no data left, a ZLP should be sent if
+      // xferred_bytes is multiple of EP size and not zero
+      if ( !tu_fifo_count(&p_midi_host->tx_ff) && xferred_bytes && (0 == (xferred_bytes % p_midi_host->ep_out_max)) )
+      {
+        if ( usbh_edpt_claim(dev_addr, p_midi_host->ep_out) )
+        {
+          TU_ASSERT(usbh_edpt_xfer(dev_addr, p_midi_host->ep_out, XFER_RESULT_SUCCESS, 0));
+        }
+      }
+    }
+    if (tuh_midi_tx_cb)
+    {
+      tuh_midi_tx_cb(dev_addr);
+    }
+  }
+
+  return true;
+}
+
+void midih_close(uint8_t dev_addr)
+{
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  if (p_midi_host == NULL)
+    return;
+  if (tuh_midi_umount_cb)
+    tuh_midi_umount_cb(dev_addr, 0);
+  tu_fifo_clear(&p_midi_host->rx_ff);
+  tu_fifo_clear(&p_midi_host->tx_ff);
+  p_midi_host->ep_in = 0;
+  p_midi_host->ep_in_max = 0;
+  p_midi_host->ep_out = 0;
+  p_midi_host->ep_out_max = 0;
+  p_midi_host->itf_num = 0;
+  p_midi_host->num_cables_rx = 0;
+  p_midi_host->num_cables_tx = 0;
+  p_midi_host->dev_addr = 255; // invalid
+  p_midi_host->configured = false;
+  tu_memclr(&p_midi_host->stream_read, sizeof(p_midi_host->stream_read));
+  tu_memclr(p_midi_host->stream_write, sizeof(p_midi_host->stream_write)*midih_limits.max_cables);
+}
+
+//--------------------------------------------------------------------+
+// Enumeration
+//--------------------------------------------------------------------+
+bool midih_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_interface_t const *desc_itf, uint16_t max_len)
+{
+  (void) rhport;
+
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+
+  TU_VERIFY(p_midi_host != NULL);
+  p_midi_host->last_xfer_result = XFER_RESULT_SUCCESS;
+#if CFG_MIDI_HOST_DEVSTRINGS
+  p_midi_host->num_string_indices = 0;
+#endif
+  TU_VERIFY(TUSB_CLASS_AUDIO == desc_itf->bInterfaceClass);
+  // There can be just a MIDI interface or an audio and a MIDI interface. Only open the MIDI interface
+  uint8_t const *p_desc = (uint8_t const *) desc_itf;
+  uint16_t len_parsed = 0;
+  if (AUDIO_SUBCLASS_CONTROL == desc_itf->bInterfaceSubClass)
+  {
+#if CFG_MIDI_HOST_DEVSTRINGS
+    // Keep track of any string descriptor that might be here
+    if (desc_itf->iInterface != 0)
+        p_midi_host->all_string_indices[p_midi_host->num_string_indices++] = desc_itf->iInterface;
+#endif
+    // This driver does not support audio streaming. However, if this is the audio control interface
+    // there might be a MIDI interface following it. Search through every descriptor until a MIDI
+    // interface is found or the end of the descriptor is found
+    while (len_parsed < max_len && (desc_itf->bInterfaceClass != TUSB_CLASS_AUDIO || desc_itf->bInterfaceSubClass != AUDIO_SUBCLASS_MIDI_STREAMING))
+    {
+      len_parsed += desc_itf->bLength;
+      p_desc = tu_desc_next(p_desc);
+      desc_itf = (tusb_desc_interface_t const *)p_desc;
+    }
+
+    TU_VERIFY(TUSB_CLASS_AUDIO == desc_itf->bInterfaceClass);
+  }
+  TU_VERIFY(AUDIO_SUBCLASS_MIDI_STREAMING == desc_itf->bInterfaceSubClass);
+  len_parsed += desc_itf->bLength;
+
+#if CFG_MIDI_HOST_DEVSTRINGS
+  // Keep track of any string descriptor that might be here
+  if (desc_itf->iInterface != 0)
+      p_midi_host->all_string_indices[p_midi_host->num_string_indices++] = desc_itf->iInterface;
+#endif
+  p_desc = tu_desc_next(p_desc);
+  TU_LOG1("MIDI opening Interface %u (addr = %u)\r\n", desc_itf->bInterfaceNumber, dev_addr);
+  // Find out if getting the MIDI class specific interface header or an endpoint descriptor
+  // or a class-specific endpoint descriptor
+  // Jack descriptors or element descriptors must follow the cs interface header,
+  // but this driver does not support devices that contain element descriptors
+
+  // assume it is an interface header
+  midi_desc_header_t const *p_mdh = (midi_desc_header_t const *)p_desc;
+  TU_VERIFY((p_mdh->bDescriptorType == TUSB_DESC_CS_INTERFACE && p_mdh->bDescriptorSubType == MIDI_CS_INTERFACE_HEADER) || 
+    (p_mdh->bDescriptorType == TUSB_DESC_CS_ENDPOINT && p_mdh->bDescriptorSubType == MIDI_CS_ENDPOINT_GENERAL) ||
+    p_mdh->bDescriptorType == TUSB_DESC_ENDPOINT);
+
+  uint8_t prev_ep_addr = 0; // the CS endpoint descriptor is associated with the previous endpoint descrptor
+  p_midi_host->itf_num = desc_itf->bInterfaceNumber;
+  tusb_desc_endpoint_t const* in_desc = NULL;
+  tusb_desc_endpoint_t const* out_desc = NULL;
+  while (len_parsed < max_len)
+  {
+    TU_VERIFY((p_mdh->bDescriptorType == TUSB_DESC_CS_INTERFACE) || 
+      (p_mdh->bDescriptorType == TUSB_DESC_CS_ENDPOINT && p_mdh->bDescriptorSubType == MIDI_CS_ENDPOINT_GENERAL) ||
+      p_mdh->bDescriptorType == TUSB_DESC_ENDPOINT);
+
+    if (p_mdh->bDescriptorType == TUSB_DESC_CS_INTERFACE) {
+      // The USB host doesn't really need this information unless it uses
+      // the string descriptor for a jack or Element
+
+      // assume it is an input jack
+      midi_desc_in_jack_t const *p_mdij = (midi_desc_in_jack_t const *)p_desc;
+      if (p_mdij->bDescriptorSubType == MIDI_CS_INTERFACE_HEADER)
+      {
+        TU_LOG2("Found MIDI Interface Header\r\b");
+      }
+      else if (p_mdij->bDescriptorSubType == MIDI_CS_INTERFACE_IN_JACK)
+      {
+        // Then it is an in jack. 
+        TU_LOG2("Found in jack\r\n");
+#if CFG_MIDI_HOST_DEVSTRINGS
+        if (p_midi_host->next_in_jack < MAX_IN_JACKS)
+        {
+          p_midi_host->in_jack_info[p_midi_host->next_in_jack].jack_id = p_mdij->bJackID;
+          p_midi_host->in_jack_info[p_midi_host->next_in_jack].jack_type = p_mdij->bJackType;
+          p_midi_host->in_jack_info[p_midi_host->next_in_jack].string_index = p_mdij->iJack;
+          ++p_midi_host->next_in_jack;
+          // Keep track of any string descriptor that might be here
+          if (p_mdij->iJack != 0)
+            p_midi_host->all_string_indices[p_midi_host->num_string_indices++] = p_mdij->iJack;
+
+        }
+#endif
+      }
+      else if (p_mdij->bDescriptorSubType == MIDI_CS_INTERFACE_OUT_JACK)
+      {
+        // then it is an out jack
+        TU_LOG2("Found out jack\r\n");
+#if CFG_MIDI_HOST_DEVSTRINGS
+        if (p_midi_host->next_out_jack < MAX_OUT_JACKS)
+        {
+          midi_desc_out_jack_t const *p_mdoj = (midi_desc_out_jack_t const *)p_desc;
+          p_midi_host->out_jack_info[p_midi_host->next_out_jack].jack_id = p_mdoj->bJackID;
+          p_midi_host->out_jack_info[p_midi_host->next_out_jack].jack_type = p_mdoj->bJackType;
+          p_midi_host->out_jack_info[p_midi_host->next_out_jack].num_source_ids = p_mdoj->bNrInputPins;
+          const struct associated_jack_s {
+              uint8_t id;
+              uint8_t pin;
+          } *associated_jack = (const struct associated_jack_s *)(p_desc+6);
+          int jack;
+          for (jack = 0; jack < p_mdoj->bNrInputPins; jack++)
+          {
+            p_midi_host->out_jack_info[p_midi_host->next_out_jack].source_ids[jack] = associated_jack->id;
+          }
+          p_midi_host->out_jack_info[p_midi_host->next_out_jack].string_index = *(p_desc+6+p_mdoj->bNrInputPins*2);
+          ++p_midi_host->next_out_jack;
+          if (p_mdoj->iJack != 0)
+            p_midi_host->all_string_indices[p_midi_host->num_string_indices++] = p_mdoj->iJack;
+        }
+#endif
+      }
+      else if (p_mdij->bDescriptorSubType == MIDI_CS_INTERFACE_ELEMENT)
+      {
+        // the it is an element;
+    #if CFG_MIDI_HOST_DEVSTRINGS
+        TU_LOG1("Found element; strings not supported\r\n");
+    #else
+        TU_LOG2("Found element\r\n");
+    #endif
+      }
+      else
+      {
+        TU_LOG2("Unknown CS Interface sub-type %u\r\n", p_mdij->bDescriptorSubType);
+        TU_VERIFY(false); // unknown CS Interface sub-type
+      }
+      len_parsed += p_mdij->bLength;
+    }
+    else if (p_mdh->bDescriptorType == TUSB_DESC_CS_ENDPOINT)
+    {
+      TU_LOG2("found CS_ENDPOINT Descriptor for %02x\r\n", prev_ep_addr);
+      TU_VERIFY(prev_ep_addr != 0);
+      // parse out the mapping between the device's embedded jacks and the endpoints
+      // Each embedded IN jack is assocated with an OUT endpoint
+      midi_cs_desc_endpoint_t const* p_csep = (midi_cs_desc_endpoint_t const*)p_mdh;
+      if (tu_edpt_dir(prev_ep_addr) == TUSB_DIR_OUT)
+      {
+        TU_VERIFY(p_midi_host->ep_out == prev_ep_addr);
+        TU_VERIFY(p_midi_host->num_cables_tx == 0);
+        p_midi_host->num_cables_tx = p_csep->bNumEmbMIDIJack;
+#if CFG_MIDI_HOST_DEVSTRINGS
+        uint8_t jack;
+        uint8_t max_jack = p_midi_host->num_cables_tx;
+        if (max_jack > sizeof(p_midi_host->ep_out_associated_jacks))
+        {
+            max_jack = sizeof(p_midi_host->ep_out_associated_jacks);
+        }
+        for (jack = 0; jack < max_jack; jack++)
+        {
+          p_midi_host->ep_out_associated_jacks[jack] = p_csep->baAssocJackID[jack];
+        }
+#endif
+      }
+      else
+      {
+        TU_VERIFY(p_midi_host->ep_in == prev_ep_addr);
+        TU_VERIFY(p_midi_host->num_cables_rx == 0);
+        p_midi_host->num_cables_rx = p_csep->bNumEmbMIDIJack;
+#if CFG_MIDI_HOST_DEVSTRINGS
+        uint8_t jack;
+        uint8_t max_jack = p_midi_host->num_cables_rx;
+        if (max_jack > sizeof(p_midi_host->ep_in_associated_jacks))
+        {
+            max_jack = sizeof(p_midi_host->ep_in_associated_jacks);
+        }
+        for (jack = 0; jack < max_jack; jack++)
+        {
+          p_midi_host->ep_in_associated_jacks[jack] = p_csep->baAssocJackID[jack];
+        }
+#endif
+      }
+      len_parsed += p_csep->bLength;
+      prev_ep_addr = 0;
+    }
+    else if (p_mdh->bDescriptorType == TUSB_DESC_ENDPOINT) {
+      // parse out the bulk endpoint info
+      tusb_desc_endpoint_t *p_ep = (tusb_desc_endpoint_t *)p_mdh;
+      TU_LOG2("found ENDPOINT Descriptor %02x\r\n", p_ep->bEndpointAddress);
+      if (p_ep->wMaxPacketSize > USBH_EPSIZE_BULK_MAX) {
+        TU_LOG2("ENDPOINT %02x wMaxPacketSize shorted from %u to %u\r\n", p_ep->bEndpointAddress, p_ep->wMaxPacketSize, USBH_EPSIZE_BULK_MAX);
+        p_ep->wMaxPacketSize = USBH_EPSIZE_BULK_MAX;
+      }
+      if (tu_edpt_dir(p_ep->bEndpointAddress) == TUSB_DIR_OUT)
+      {
+        TU_VERIFY(p_midi_host->ep_out == 0);
+        TU_VERIFY(p_midi_host->num_cables_tx == 0);
+        p_midi_host->ep_out = p_ep->bEndpointAddress;
+        p_midi_host->ep_out_max = p_ep->wMaxPacketSize;
+        if (p_midi_host->ep_out_max > midih_limits.midi_tx_buf)
+          p_midi_host->ep_out_max = midih_limits.midi_tx_buf;
+        prev_ep_addr = p_midi_host->ep_out;
+        out_desc = p_ep;
+      }
+      else
+      {
+        TU_VERIFY(p_midi_host->ep_in == 0);
+        TU_VERIFY(p_midi_host->num_cables_rx == 0);
+        p_midi_host->ep_in = p_ep->bEndpointAddress;
+        p_midi_host->ep_in_max = p_ep->wMaxPacketSize;
+        if (p_midi_host->ep_in_max > midih_limits.midi_rx_buf)
+          p_midi_host->ep_in_max = midih_limits.midi_rx_buf;
+        prev_ep_addr = p_midi_host->ep_in;
+        in_desc = p_ep;
+      }
+      len_parsed += p_mdh->bLength;
+    }
+    p_desc = tu_desc_next(p_desc);
+    p_mdh = (midi_desc_header_t const *)p_desc;
+  }
+  TU_VERIFY((p_midi_host->ep_out != 0 && p_midi_host->num_cables_tx != 0) ||
+            (p_midi_host->ep_in != 0 && p_midi_host->num_cables_rx != 0));
+  TU_LOG1("MIDI descriptor parsed successfully\r\n");
+#if CFG_MIDI_HOST_DEVSTRINGS
+  // remove duplicate string indices
+  for (int idx=0; idx < p_midi_host->num_string_indices; idx++) {
+      for (int jdx = idx+1; jdx < p_midi_host->num_string_indices; jdx++) {
+          while (jdx < p_midi_host->num_string_indices &&  p_midi_host->all_string_indices[idx] == p_midi_host->all_string_indices[jdx]) {
+              // delete the duplicate by overwriting it with the last entry and reducing the number of entries by 1
+              p_midi_host->all_string_indices[jdx] = p_midi_host->all_string_indices[p_midi_host->num_string_indices-1];
+              --p_midi_host->num_string_indices;
+          }
+      }
+  }
+#endif
+  if (in_desc)
+  {
+    TU_ASSERT(tuh_edpt_open(dev_addr, in_desc));
+    // Some devices always return exactly the request length so transfers won't complete
+    // unless you assume every transfer is the last one.
+    // TODO usbh_edpt_force_last_buffer(dev_addr, p_midi_host->ep_in, true);
+  }
+  if (out_desc)
+  {
+    TU_ASSERT(tuh_edpt_open(dev_addr, out_desc));
+  }
+  p_midi_host->dev_addr = dev_addr;
+
+  return true;
+}
+
+bool tuh_midi_configured(uint8_t dev_addr)
+{
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  TU_VERIFY(p_midi_host != NULL);
+  return p_midi_host->configured;
+}
+
+bool midih_set_config(uint8_t dev_addr, uint8_t itf_num)
+{
+  (void) itf_num;
+  TU_LOG2("Set config dev_addr=%u\r\n", dev_addr);
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  TU_VERIFY(p_midi_host != NULL);
+  p_midi_host->configured = true;
+
+  TU_LOG2("Requesting poll IN endpoint %d\r\n", p_midi_host->ep_in);
+  TU_ASSERT(usbh_edpt_xfer(p_midi_host->dev_addr, p_midi_host->ep_in, p_midi_host->epin_buf, p_midi_host->ep_in_max), 0);
+  if (tuh_midi_mount_cb)
+  {
+    tuh_midi_mount_cb(dev_addr, p_midi_host->ep_in, p_midi_host->ep_out, p_midi_host->num_cables_rx, p_midi_host->num_cables_tx);
+  }
+  usbh_driver_set_config_complete(dev_addr, itf_num);
+  return true;
+}
+
+//--------------------------------------------------------------------+
+// Stream API
+//--------------------------------------------------------------------+
+static uint32_t write_flush(uint8_t dev_addr, midih_interface_t* midi)
+{
+  // No data to send
+  if ( !tu_fifo_count(&midi->tx_ff) ) return 0;
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  TU_VERIFY(p_midi_host != NULL);
+  if (p_midi_host->last_xfer_result != XFER_RESULT_SUCCESS) return 0;
+
+  // skip if previous transfer not complete
+  TU_VERIFY( usbh_edpt_claim(dev_addr, midi->ep_out) );
+
+  uint16_t count = tu_fifo_read_n(&midi->tx_ff, midi->epout_buf, midi->ep_out_max);
+
+  if (count)
+  {
+    TU_ASSERT( usbh_edpt_xfer(dev_addr, midi->ep_out, midi->epout_buf, count), 0 );
+    return count;
+  }else
+  {
+    // Release endpoint since we don't make any transfer
+    usbh_edpt_release(dev_addr, midi->ep_out);
+    return 0;
+  }
+}
+
+bool tuh_midi_can_write_stream (uint8_t dev_addr)
+{
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  return (tu_fifo_remaining(&p_midi_host->tx_ff) >= 4);
+}
+
+uint32_t tuh_midi_stream_write (uint8_t dev_addr, uint8_t cable_num, uint8_t const* buffer, uint32_t bufsize)
+{
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  TU_VERIFY(p_midi_host != NULL);
+  TU_VERIFY(cable_num < p_midi_host->num_cables_tx);
+  TU_VERIFY(cable_num < midih_limits.max_cables);
+  midi_stream_t *stream = &p_midi_host->stream_write[cable_num];
+
+  uint32_t i = 0;
+  uint8_t const CN_ = cable_num << 4;
+
+  while ( (i < bufsize) && (tu_fifo_remaining(&p_midi_host->tx_ff) >= 4) )
+  {
+    uint8_t const data = buffer[i];
+    i++;
+
+    if (data >= MIDI_STATUS_SYSREAL_TIMING_CLOCK)
+    {
+        // real-time messages need to be sent right away
+        midi_stream_t streamrt;
+        streamrt.buffer[0] = CN_ + MIDI_CIN_1BYTE_DATA;
+        streamrt.buffer[1] = data;
+        streamrt.buffer[2] = 0;
+        streamrt.buffer[3] = 0;
+
+        uint16_t const count = tu_fifo_write_n(&p_midi_host->tx_ff, streamrt.buffer, 4);
+        // FIFO overflown, since we already check fifo remaining. It is probably race condition
+        TU_ASSERT(count == 4, i);
+    }
+    else if ( stream->index == 0 )
+    {
+      //------------- New event packet -------------//
+
+      uint8_t const msg = data >> 4;
+      uint8_t const _msg = (stream->buffer[0]) & 0x0F;
+      stream->index = 2;
+      //stream->buffer[1] = data; //first check if its a running status byte, then update
+      stream->total = 4;
+
+      // Check to see if we're still in a SysEx transmit.
+      if ( _msg == MIDI_CIN_SYSEX_START)
+      {
+        stream->buffer[1] = data;
+
+        if ( data == MIDI_STATUS_SYSEX_END )
+        {
+          stream->buffer[0] = CN_ + MIDI_CIN_SYSEX_END_1BYTE;
+          stream->total = 2;
+        }
+      }
+      else if (msg < 0x8 && _msg >= 0x8 && _msg < 0xF)   //Running Status ?
+      {
+        //stream->buffer[0] leave;
+        //stream->buffer[1] leave;
+        stream->buffer[2] = data;
+
+        if (_msg < 0xC || _msg == 0xE)
+        {
+            stream->index = 3;
+        }
+        else    //if (_msg < 0xF)
+        {
+            stream->index = 3;
+            stream->total = 3;
+        }
+      }
+      else if ( (msg >= 0x8 && msg <= 0xB) || msg == 0xE )
+      {
+        // Channel Voice Messages
+        stream->buffer[1] = data;
+        stream->buffer[0] = CN_ + msg;
+      }
+      else if ( msg == 0xC || msg == 0xD)
+      {
+        // Channel Voice Messages, two-byte variants (Program Change and Channel Pressure)
+        stream->buffer[1] = data;
+        stream->buffer[0] = CN_ + msg;
+        stream->total = 3;
+      }
+      else if ( msg == 0xf )
+      {
+        // System message
+        stream->buffer[1] = data;
+
+        if ( data == MIDI_STATUS_SYSEX_START )
+        {
+          stream->buffer[0] = CN_ + MIDI_CIN_SYSEX_START;
+        }
+        else if ( data == MIDI_STATUS_SYSCOM_TIME_CODE_QUARTER_FRAME || data == MIDI_STATUS_SYSCOM_SONG_SELECT )
+        {
+          stream->buffer[0] = CN_ + MIDI_CIN_SYSCOM_2BYTE;
+          stream->total = 3;
+        }
+        else if ( data == MIDI_STATUS_SYSCOM_SONG_POSITION_POINTER )
+        {
+          stream->buffer[0] = CN_ + MIDI_CIN_SYSCOM_3BYTE;
+        }
+        else        //for example, MIDI_STATUS_SYSCOM_TUNE_REQUEST
+        {
+          stream->buffer[0] = CN_ + MIDI_CIN_1BYTE_DATA;
+          stream->total = 2;
+        }
+      }
+      else
+      {
+        // Pack individual bytes if we don't support packing them into words.
+        stream->buffer[1] = data;
+        stream->buffer[0] = CN_ + 0xF;
+        stream->index = 2;
+        stream->total = 2;
+      }
+    }   //End of: if (stream->index == 0)
+    else
+    {
+      //------------- On-going (buffering) packet -------------//
+
+      TU_ASSERT(stream->index < 4, i);
+      stream->buffer[stream->index] = data;
+      stream->index++;
+      // See if this byte ends a SysEx.
+      if ( stream->buffer[0] == CN_ + MIDI_CIN_SYSEX_START && data == MIDI_STATUS_SYSEX_END )
+      {
+        stream->buffer[0] = CN_ + MIDI_CIN_SYSEX_START + (stream->index - 1);   //END +1/+2/+3 Bytes
+        stream->total = stream->index;
+      }
+    }
+
+    // Send out packet
+    if ( stream->index >= 2 && stream->index >= stream->total )
+    {
+      //zeroes unused bytes
+      for(uint8_t idx = stream->total; idx < 4; idx++) stream->buffer[idx] = 0;
+      TU_LOG3_MEM(stream->buffer, 4, 2);
+
+      uint16_t const count = tu_fifo_write_n(&p_midi_host->tx_ff, stream->buffer, 4);
+
+      stream->index = 0;
+
+      // FIFO overflown, since we already check fifo remaining. It is probably race condition
+      TU_ASSERT(count == 4, i);
+    }
+  }
+
+  return i;
+}
+
+
+bool tuh_midi_packet_write (uint8_t dev_addr, uint8_t const packet[4])
+{
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  TU_VERIFY(p_midi_host != NULL);
+
+  if (tu_fifo_remaining(&p_midi_host->tx_ff) < 4)
+  {
+    return false;
+  }
+
+  tu_fifo_write_n(&p_midi_host->tx_ff, packet, 4);
+
+  return true;
+}
+
+uint32_t tuh_midi_stream_flush( uint8_t dev_addr )
+{
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  TU_VERIFY(p_midi_host != NULL);
+
+  uint32_t bytes_flushed = 0;
+  if (!usbh_edpt_busy(p_midi_host->dev_addr, p_midi_host->ep_out))
+  {
+    bytes_flushed = write_flush(dev_addr, p_midi_host);
+  }
+  return bytes_flushed;
+}
+//--------------------------------------------------------------------+
+// Helper
+//--------------------------------------------------------------------+
+uint8_t tuh_midih_get_num_tx_cables (uint8_t dev_addr)
+{
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  TU_VERIFY(p_midi_host != NULL);
+  TU_VERIFY(p_midi_host->ep_out != 0); // returns 0 if fails
+  return p_midi_host->num_cables_tx;
+}
+
+uint8_t tuh_midih_get_num_rx_cables (uint8_t dev_addr)
+{
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  TU_VERIFY(p_midi_host != NULL);
+  TU_VERIFY(p_midi_host->ep_in != 0); // returns 0 if fails
+  return p_midi_host->num_cables_rx;
+}
+
+bool tuh_midi_packet_read (uint8_t dev_addr, uint8_t packet[4])
+{
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  TU_VERIFY(p_midi_host != NULL);
+  TU_VERIFY(tu_fifo_count(&p_midi_host->rx_ff) >= 4);
+  return tu_fifo_read_n(&p_midi_host->rx_ff, packet, 4) == 4;
+}
+
+uint32_t tuh_midi_stream_read (uint8_t dev_addr, uint8_t *p_cable_num, uint8_t *p_buffer, uint16_t bufsize)
+{
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  TU_VERIFY(p_midi_host != NULL);
+  uint32_t bytes_buffered = 0;
+  TU_ASSERT(p_cable_num);
+  TU_ASSERT(p_buffer);
+  TU_ASSERT(bufsize);
+  uint8_t one_byte;
+  if (!tu_fifo_peek(&p_midi_host->rx_ff, &one_byte))
+  {
+    return 0;
+  }
+  *p_cable_num = (one_byte >> 4) & 0xf;
+  uint32_t nread = tu_fifo_read_n(&p_midi_host->rx_ff, p_midi_host->stream_read.buffer, 4);
+  static uint16_t cable_sysex_in_progress; // bit i is set if received MIDI_STATUS_SYSEX_START but not MIDI_STATUS_SYSEX_END
+  while (nread == 4 && bytes_buffered < bufsize)
+  {
+    *p_cable_num=(p_midi_host->stream_read.buffer[0] >> 4) & 0x0f;
+    uint8_t bytes_to_add_to_stream = 0;
+    if (*p_cable_num < p_midi_host->num_cables_rx)
+    {
+      // ignore the CIN field; too many devices out there encode this wrong
+      uint8_t status = p_midi_host->stream_read.buffer[1];
+      uint16_t cable_mask = (uint16_t) (1 << *p_cable_num);
+      if (status <= MIDI_MAX_DATA_VAL || status == MIDI_STATUS_SYSEX_START)
+      {
+        if (status == MIDI_STATUS_SYSEX_START)
+        {
+          cable_sysex_in_progress |= cable_mask;
+        }
+        // only add the packet if a sysex message is in progress
+        if (cable_sysex_in_progress & cable_mask)
+        {
+          ++bytes_to_add_to_stream;
+          uint8_t idx;
+          for (idx = 2; idx < 4; idx++)
+          {
+            if (p_midi_host->stream_read.buffer[idx] <= MIDI_MAX_DATA_VAL)
+            {
+              ++bytes_to_add_to_stream;
+            }
+            else if (p_midi_host->stream_read.buffer[idx] == MIDI_STATUS_SYSEX_END)
+            {
+              ++bytes_to_add_to_stream;
+              cable_sysex_in_progress &= (uint16_t) ~cable_mask;
+              idx = 4; // force the loop to exit; I hate break statements in loops
+            }
+          }
+        }
+      }
+      else if (status < MIDI_STATUS_SYSEX_START)
+      {
+        // then it is a channel message either three bytes or two
+        uint8_t fake_cin = (status & 0xf0) >> 4;
+        switch (fake_cin)
+        {
+          case MIDI_CIN_NOTE_OFF:
+          case MIDI_CIN_NOTE_ON:
+          case MIDI_CIN_POLY_KEYPRESS:
+          case MIDI_CIN_CONTROL_CHANGE:
+          case MIDI_CIN_PITCH_BEND_CHANGE:
+            bytes_to_add_to_stream = 3;
+            break;
+          case MIDI_CIN_PROGRAM_CHANGE:
+          case MIDI_CIN_CHANNEL_PRESSURE:
+            bytes_to_add_to_stream = 2;
+            break;
+          default:
+            break; // Should not get this
+        }
+        cable_sysex_in_progress &= (uint16_t)~cable_mask;
+      }
+      else if (status < MIDI_STATUS_SYSREAL_TIMING_CLOCK)
+      {
+        switch (status)
+        {
+          case MIDI_STATUS_SYSCOM_TIME_CODE_QUARTER_FRAME:
+          case MIDI_STATUS_SYSCOM_SONG_SELECT:
+            bytes_to_add_to_stream = 2;
+            break;
+          case MIDI_STATUS_SYSCOM_SONG_POSITION_POINTER:
+            bytes_to_add_to_stream = 3;
+            break;
+          case MIDI_STATUS_SYSCOM_TUNE_REQUEST:
+          case MIDI_STATUS_SYSEX_END:
+            bytes_to_add_to_stream = 1;
+            break;
+          default:
+            break;
+          cable_sysex_in_progress &= (uint16_t)~cable_mask;
+        }
+      }
+      else
+      {
+        // Real-time message: can be inserted into a sysex message,
+        // so do don't clear cable_sysex_in_progress bit
+        bytes_to_add_to_stream = 1;
+      }
+    }
+    uint8_t idx;
+    for (idx = 1; idx <= bytes_to_add_to_stream; idx++)
+    {
+      *p_buffer++ = p_midi_host->stream_read.buffer[idx];
+    }
+    bytes_buffered += bytes_to_add_to_stream;
+    nread = 0;
+    if (tu_fifo_peek(&p_midi_host->rx_ff, &one_byte))
+    {
+      uint8_t new_cable = (one_byte >> 4) & 0xf;
+      if (new_cable == *p_cable_num)
+      {
+        // still on the same cable. Continue reading the stream
+        nread = tu_fifo_read_n(&p_midi_host->rx_ff, p_midi_host->stream_read.buffer, 4);
+      }
+    }
+  }
+
+  return bytes_buffered;
+}
+
+uint8_t tuh_midi_get_num_rx_cables(uint8_t dev_addr)
+{
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  TU_VERIFY(p_midi_host != NULL);
+  uint8_t num_cables = 0;
+  if (p_midi_host)
+  {
+    num_cables = p_midi_host->num_cables_rx;
+  }
+  return num_cables;
+}
+
+uint8_t tuh_midi_get_num_tx_cables(uint8_t dev_addr)
+{
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  TU_VERIFY(p_midi_host != NULL);
+  uint8_t num_cables = 0;
+  if (p_midi_host)
+  {
+    num_cables = p_midi_host->num_cables_tx;
+  }
+  return num_cables;
+}
+
+#if CFG_MIDI_HOST_DEVSTRINGS
+static uint8_t find_string_index(midih_interface_t *ptr, uint8_t jack_id)
+{
+  uint8_t index = 0;
+  uint8_t assoc;
+  for (assoc = 0; index == 0 && assoc < ptr->next_in_jack; assoc++)
+  {
+    if (jack_id == ptr->in_jack_info[assoc].jack_id)
+    {
+      index = ptr->in_jack_info[assoc].string_index;
+    }
+  }
+  for (assoc = 0; index == 0 && assoc < ptr->next_out_jack; assoc++)
+  {
+    if (jack_id == ptr->out_jack_info[assoc].jack_id)
+    {
+      index = ptr->out_jack_info[assoc].string_index;
+    }
+  }
+  return index;
+}
+#endif
+
+#if CFG_MIDI_HOST_DEVSTRINGS
+uint8_t tuh_midi_get_rx_cable_istrings(uint8_t dev_addr, uint8_t* istrings, uint8_t max_istrings)
+{
+  uint8_t nstrings = 0;
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  TU_VERIFY(p_midi_host != NULL);
+  nstrings = p_midi_host->num_cables_rx;
+  if (nstrings > max_istrings)
+  {
+      nstrings = max_istrings;
+  }
+  uint8_t jack;
+  for (jack=0; jack<nstrings; jack++)
+  {
+    uint8_t jack_id = p_midi_host->ep_in_associated_jacks[jack];
+    istrings[jack] = find_string_index(p_midi_host, jack_id);
+  }
+  return nstrings;
+}
+
+uint8_t tuh_midi_get_tx_cable_istrings(uint8_t dev_addr, uint8_t* istrings, uint8_t max_istrings)
+{
+  uint8_t nstrings = 0;
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  TU_VERIFY(p_midi_host != NULL);
+  nstrings = p_midi_host->num_cables_tx;
+  if (nstrings > max_istrings)
+  {
+      nstrings = max_istrings;
+  }
+  uint8_t jack;
+  for (jack=0; jack<nstrings; jack++)
+  {
+    uint8_t jack_id = p_midi_host->ep_out_associated_jacks[jack];
+    istrings[jack] = find_string_index(p_midi_host, jack_id);
+  }
+  return nstrings;
+}
+
+uint8_t tuh_midi_get_all_istrings(uint8_t dev_addr, const uint8_t** istrings)
+{
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  TU_VERIFY(p_midi_host != NULL);
+  uint8_t nstrings = p_midi_host->num_string_indices;
+  if (nstrings)
+    *istrings = p_midi_host->all_string_indices;
+  return nstrings;
+}
+#endif
+#endif

--- a/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/examples/midi_device_host/usb_midi_host.h
+++ b/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/examples/midi_device_host/usb_midi_host.h
@@ -1,0 +1,172 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 rppicomidi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#ifndef _TUSB_MIDI_HOST_H_
+#define _TUSB_MIDI_HOST_H_
+
+#include "class/audio/audio.h"
+#include "class/midi/midi.h"
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+//--------------------------------------------------------------------+
+// Class Driver Configuration
+//--------------------------------------------------------------------+
+// Use this function in Arduino or other environments where modifying
+// the tusb_config.h file is not practical.
+// Call this before midih_init() gets called by the TinyUSB stack,
+// which is before the application calls tusb_init() or tuh_init().
+// Calling this function after midih_init() will cause problems.
+//
+// Note: To figure out how long a USB MIDI 1.0 stream needs to be
+// in bytes, multiply the number of bytes in the stream by 4/3 and
+// round up to the nearest 4 bytes.
+// For exampe, to send a 146 byte SysEx message, 146*4/3 = 194.66...
+// The next nearest 4 byte boundary is 196. So the buffer is 196 bytes,
+// or 49 4-byte USB MIDI packets.
+//
+// Parameters:
+// midi_rx_buffer_bytes is the number of bytes the USB Host can buffer
+// from the device. This has to be at least equal to the maximum bulk
+// transfer size of 64 bytes, but it is a good idea to set this to
+// at least the maximum SysEx message size in MIDI packets to improve
+// throughput.
+//
+// midi_tx_buffer_bytes is the maximum number of bytes the application
+// can write out to the interface in a single transaction. This should
+// be at least as large as the maximum bulk transfer size of 64 bytes.
+// To send long SysEx messages, you should make this buffer at least as
+// long as the longest message in MIDI packets or else SysEx message
+// writes may get truncated.
+//
+// max_cables defaults to 16. If you know you only need to convert
+// serial MIDI data to USB MIDI packets from cable numbers 0:N,
+// and N is less than 15, you can save a small amount
+// if RAM if you set this value to something less than 16.
+// For example, if your application is to convert a single
+// Serial Port MIDI to USB, then the highest cable number
+// is 0, so you only need one virtual cable. You will save the
+// deserialization buffer for 15 virtual cables (about 90 bytes).
+//
+void tuh_midih_define_limits(size_t midi_rx_buffer_bytes, size_t midi_tx_buffer_bytes, uint8_t max_cables);
+
+#ifndef CFG_MIDI_HOST_DEVSTRINGS
+#ifdef ARDUINO
+#define CFG_MIDI_HOST_DEVSTRINGS 1
+#else
+#define CFG_MIDI_HOST_DEVSTRINGS 0
+#endif
+#endif
+
+//--------------------------------------------------------------------+
+// Application API (Single Interface)
+//--------------------------------------------------------------------+
+
+bool     tuh_midi_configured      (uint8_t dev_addr);
+
+// return the number of virtual midi cables on the device's OUT endpoint
+uint8_t tuh_midih_get_num_tx_cables (uint8_t dev_addr);
+
+// return the number of virtual midi cables on the device's IN endpoint
+uint8_t tuh_midih_get_num_rx_cables (uint8_t dev_addr);
+
+// Queue a packet to the device. The application
+// must call tuh_midi_stream_flush to actually have the
+// data go out. It is up to the application to properly
+// format this packet; this function does not check.
+// Using this function with tuh_midi_stream_write()
+// might produce undefined behavior.
+// Returns true if the packet was successfully queued.
+bool tuh_midi_packet_write (uint8_t dev_addr, uint8_t const packet[4]);
+
+// Queue a message to the device. The application
+// must call tuh_midi_stream_flush to actually have the
+// data go out. Note that cable_num must be < CFG_TUH_CABLE_MAX
+// (note CFG_TUH_CABLE_MAX default is 16)
+uint32_t tuh_midi_stream_write (uint8_t dev_addr, uint8_t cable_num, uint8_t const* p_buffer, uint32_t bufsize);
+
+/// Return true if the MIDI OUT FIFO has enough space for at
+/// least one more message
+bool tuh_midi_can_write_stream (uint8_t dev_addr);
+
+// Send any queued packets to the device if the host hardware is able to do it
+// Returns the number of bytes flushed to the host hardware or 0 if
+// the host hardware is busy or there is nothing in queue to send.
+uint32_t tuh_midi_stream_flush( uint8_t dev_addr);
+
+// Get the MIDI stream from the device. Set the value pointed
+// to by p_cable_num to the MIDI cable number intended to receive it.
+// The MIDI stream will be stored in the buffer pointed to by p_buffer.
+// Return the number of bytes added to the buffer.
+// Note that this function ignores the CIN field of the MIDI packet
+// because a number of commercial devices out there do not encode
+// it properly.
+uint32_t tuh_midi_stream_read (uint8_t dev_addr, uint8_t *p_cable_num, uint8_t *p_buffer, uint16_t bufsize);
+
+// Read a raw MIDI packet from the connected device
+// This function does not parse the packet format
+// Return true if a packet was returned
+bool tuh_midi_packet_read (uint8_t dev_addr, uint8_t packet[4]);
+
+uint8_t tuh_midi_get_num_rx_cables(uint8_t dev_addr);
+uint8_t tuh_midi_get_num_tx_cables(uint8_t dev_addr);
+#if CFG_MIDI_HOST_DEVSTRINGS
+uint8_t tuh_midi_get_rx_cable_istrings(uint8_t dev_addr, uint8_t* istrings, uint8_t max_istrings);
+uint8_t tuh_midi_get_tx_cable_istrings(uint8_t dev_addr, uint8_t* istrings, uint8_t max_istrings);
+uint8_t tuh_midi_get_all_istrings(uint8_t dev_addr, const uint8_t** istrings);
+#endif
+//--------------------------------------------------------------------+
+// Internal Class Driver API
+//--------------------------------------------------------------------+
+bool midih_init       (void);
+bool midih_deinit     (void);
+bool midih_open       (uint8_t rhport, uint8_t dev_addr, tusb_desc_interface_t const *desc_itf, uint16_t max_len);
+bool midih_set_config (uint8_t dev_addr, uint8_t itf_num);
+bool midih_xfer_cb    (uint8_t dev_addr, uint8_t ep_addr, xfer_result_t result, uint32_t xferred_bytes);
+void midih_close      (uint8_t dev_addr);
+
+//--------------------------------------------------------------------+
+// Callbacks (Weak is optional)
+//--------------------------------------------------------------------+
+
+// Invoked when device with MIDI interface is mounted.
+// If the MIDI host application requires MIDI IN, it should requst an
+// IN transfer here. The device will likely NAK this transfer. How the driver
+// handles the NAK is hardware dependent.
+TU_ATTR_WEAK void tuh_midi_mount_cb(uint8_t dev_addr, uint8_t in_ep, uint8_t out_ep, uint8_t num_cables_rx, uint16_t num_cables_tx);
+
+// Invoked when device with MIDI interface is un-mounted
+// For now, the instance parameter is always 0 and can be ignored
+TU_ATTR_WEAK void tuh_midi_umount_cb(uint8_t dev_addr, uint8_t instance);
+
+TU_ATTR_WEAK void tuh_midi_rx_cb(uint8_t dev_addr, uint32_t num_packets);
+TU_ATTR_WEAK void tuh_midi_tx_cb(uint8_t dev_addr);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _TUSB_MIDI_HOST_H_ */

--- a/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/examples/midi_device_host/usb_midi_host_app_driver.c
+++ b/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/examples/midi_device_host/usb_midi_host_app_driver.c
@@ -1,0 +1,50 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 rppicomidi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+#include "tusb_option.h"
+
+#if (TUSB_OPT_HOST_ENABLED)
+
+#include "host/usbh.h"
+#include "host/usbh_pvt.h"
+
+#include "usb_midi_host.h"
+
+// Install the USB MIDI Host class driver
+usbh_class_driver_t const* usbh_app_driver_get_cb(uint8_t* driver_count)
+{
+  static usbh_class_driver_t host_driver = {
+  #if CFG_TUSB_DEBUG >= 2
+    .name = "MIDIH",
+  #endif
+    .init=midih_init,
+    .deinit=midih_deinit,
+    .open=midih_open,
+    .set_config=midih_set_config,
+    .xfer_cb = midih_xfer_cb,
+    .close = midih_close };
+  *driver_count = 1;
+  return &host_driver;
+}
+#endif

--- a/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/examples/midi_host/main.cpp
+++ b/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/examples/midi_host/main.cpp
@@ -1,0 +1,191 @@
+// USB host MIDI example
+// using https://github.com/rppicomidi/usb_midi_host
+//
+// USB host means that the MTM Computer connects to (and may provide power to) USB devices
+// such as MIDI controllers/keyboards, the 8mu, etc.
+
+// To connect with USB to a laptop/desktop computer (which itself acts as a USB host),
+// see the usb_device example.
+
+
+// This is a very slightly modified 
+
+#include "ComputerCard.h"
+
+#include "pico/multicore.h"
+#include "bsp/board.h"
+#include "tusb.h"
+#include "usb_midi_host.h"
+
+
+
+
+class MIDIHost : public ComputerCard
+{
+public:
+	MIDIHost()
+	{
+		midi_dev_addr = 0;
+		device_connected = 0;
+		
+		counter = 0;
+		
+		// Start the second core
+		multicore_launch_core1(core1);
+	}
+
+	// Boilerplate to call member function as second core
+	static void core1()
+	{
+		((MIDIHost *)ThisPtr())->USBCore();
+	}
+
+	// Send alternate note-on and note-off messages
+	void SendNextNote()
+	{
+		static uint8_t noteOn[3] = {0x90, 0x5f, 0x7f};
+		static uint8_t noteOff[3] = {0x80, 0x5f, 0x00};
+		static bool noteOnNext = true;
+
+		// Transmit the note message on the highest cable number
+		uint8_t cable = tuh_midih_get_num_tx_cables(midi_dev_addr) - 1;
+
+
+		// Toggle between sending note-on and note-off messages
+		if (noteOnNext)
+		{
+			tuh_midi_stream_write(midi_dev_addr, cable, noteOn, sizeof(noteOn));
+			noteOnNext = false;
+		}
+		else
+		{
+			tuh_midi_stream_write(midi_dev_addr, cable, noteOff, sizeof(noteOff));
+			noteOnNext = true;
+		}
+	}
+
+	
+	// Code for second RP2040 core, blocking
+	// Handles MIDI in/out messages
+	void USBCore()
+	{
+		// Initialise TinyUSB
+		board_init();
+		tusb_init();
+		
+		while (1)
+		{
+			tuh_task();
+		
+			bool connected = midi_dev_addr != 0 && tuh_midi_configured(midi_dev_addr);
+
+			// device must be attached and have at least one endpoint ready to receive a message
+			if (connected && tuh_midih_get_num_tx_cables(midi_dev_addr) >= 1)
+			{
+
+				if (counter >= 20000)
+				{
+					SendNextNote();
+					counter -= 20000;
+				}
+
+				// Send a USB packet immediately (even though in this case,
+				// we are not close to the 64-byte maximum payload)
+ 				tuh_midi_stream_flush(midi_dev_addr);
+			}
+		}
+
+	}
+
+	
+	// 48kHz audio processing function
+	virtual void ProcessSample()
+	{
+		// No audio I/O, so just flash an LED
+		// to indicate that the card is running
+		LedOn(5, counter < 10000);
+
+		// LED 4 indicates whether MIDI device is connected
+		LedOn(4, device_connected);
+		
+		// Counter is reset by other core
+		if (counter <= 30000)
+			counter++;
+	}
+	
+	static uint8_t device_connected;
+	static uint8_t midi_dev_addr;
+	
+private:
+	volatile uint32_t counter;
+};
+
+
+uint8_t MIDIHost::device_connected;
+uint8_t MIDIHost::midi_dev_addr;
+
+
+// Four callback functions that rppicomidi/usb_midi_host uses
+
+void tuh_midi_mount_cb(uint8_t dev_addr, uint8_t in_ep, uint8_t out_ep, uint8_t num_cables_rx, uint16_t num_cables_tx)
+{
+	(void)in_ep; (void)out_ep; (void)num_cables_rx; (void)num_cables_tx; // avoid unused variable warnings
+
+	
+	if (MIDIHost::midi_dev_addr == 0)
+	{
+		MIDIHost::midi_dev_addr = dev_addr;
+		MIDIHost::device_connected = 1;
+	}
+}
+
+void tuh_midi_umount_cb(uint8_t dev_addr, uint8_t instance)
+{
+	(void)instance;
+	
+	if (dev_addr == MIDIHost::midi_dev_addr)
+	{
+		MIDIHost::midi_dev_addr = 0;
+		MIDIHost::device_connected = 0;
+	}
+}
+
+void tuh_midi_rx_cb(uint8_t dev_addr, uint32_t num_packets)
+{
+	if (MIDIHost::midi_dev_addr != dev_addr)
+		return;
+
+	if (num_packets == 0)
+		return;
+	
+	uint8_t cable_num;
+	uint8_t buffer[48];
+	while (1)
+	{
+		uint32_t bytes_read = tuh_midi_stream_read(dev_addr, &cable_num, buffer, sizeof(buffer));
+
+		if (bytes_read == 0)
+			return;
+		
+		for (uint32_t idx = 0; idx < bytes_read; idx++)
+		{
+			//buffer[idx]
+		}
+	}
+
+}
+
+void tuh_midi_tx_cb(uint8_t dev_addr)
+{
+    (void)dev_addr;
+}
+
+
+
+int main()
+{
+	MIDIHost mh;
+	mh.Run();
+}
+
+  

--- a/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/examples/midi_host/tusb_config.h
+++ b/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/examples/midi_host/tusb_config.h
@@ -1,0 +1,98 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ha Thach (tinyusb.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#ifndef _TUSB_CONFIG_H_
+#define _TUSB_CONFIG_H_
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+//--------------------------------------------------------------------
+// COMMON CONFIGURATION
+//--------------------------------------------------------------------
+
+// defined by compiler flags for flexibility
+#ifndef CFG_TUSB_MCU
+  #error CFG_TUSB_MCU must be defined
+#endif
+
+#if CFG_TUSB_MCU == OPT_MCU_LPC43XX || CFG_TUSB_MCU == OPT_MCU_LPC18XX || CFG_TUSB_MCU == OPT_MCU_MIMXRT10XX
+  #define CFG_TUSB_RHPORT0_MODE       (OPT_MODE_HOST | OPT_MODE_HIGH_SPEED)
+#else
+  #define CFG_TUSB_RHPORT0_MODE       OPT_MODE_HOST
+#endif
+
+#ifndef CFG_TUSB_OS
+#define CFG_TUSB_OS                 OPT_OS_NONE
+#endif
+
+// TODO Do we need this?
+//#if CFG_TUSB_MCU == OPT_MCU_RP2040
+//#define PICO_RP2040_USB_FAST_IRQ 1
+//#endif
+// CFG_TUSB_DEBUG is defined by compiler in DEBUG build
+// #define CFG_TUSB_DEBUG           0
+
+/* USB DMA on some MCUs can only access a specific SRAM region with restriction on alignment.
+ * Tinyusb use follows macros to declare transferring memory so that they can be put
+ * into those specific section.
+ * e.g
+ * - CFG_TUSB_MEM SECTION : __attribute__ (( section(".usb_ram") ))
+ * - CFG_TUSB_MEM_ALIGN   : __attribute__ ((aligned(4)))
+ */
+#ifndef CFG_TUSB_MEM_SECTION
+#define CFG_TUSB_MEM_SECTION
+#endif
+
+#ifndef CFG_TUSB_MEM_ALIGN
+#define CFG_TUSB_MEM_ALIGN          __attribute__ ((aligned(4)))
+#endif
+
+//--------------------------------------------------------------------
+// CONFIGURATION
+//--------------------------------------------------------------------
+
+// Size of buffer to hold descriptors and other data used for enumeration
+#define CFG_TUH_ENUMERATION_BUFSIZE 256
+
+#define CFG_TUH_HUB                 1 // Enable USB hubs
+#define CFG_TUH_CDC                 0
+#define CFG_TUH_HID                 0 // typical keyboard + mouse device can have 3-4 HID interfaces
+//NOTE: Do note #define CFG_TUH_MIDI 1 to enable MIDI Host. A code fragment in usbh.c that breaks the build if you do that
+#define CFG_TUH_MSC                 1
+#define CFG_TUH_VENDOR              0
+
+// max device support (excluding hub device)
+#define CFG_TUH_DEVICE_MAX          (CFG_TUH_HUB ? 4 : 1) // hub typically has 4 ports
+
+// MIDI Host string support
+#define CFG_MIDI_HOST_DEVSTRINGS 1
+
+#ifdef __cplusplus
+ }
+#endif
+
+#endif /* _TUSB_CONFIG_H_ */

--- a/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/examples/midi_host/usb_midi_host.c
+++ b/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/examples/midi_host/usb_midi_host.c
@@ -1,0 +1,1034 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 rppicomidi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include "tusb_option.h"
+
+#if (TUSB_OPT_HOST_ENABLED)
+
+#include "host/usbh.h"
+#include "host/usbh_pvt.h"
+
+#include "usb_midi_host.h"
+#include <stdlib.h>
+//--------------------------------------------------------------------+
+// MACRO CONSTANT TYPEDEF
+//--------------------------------------------------------------------+
+#ifndef CFG_TUH_MAX_CABLES
+  #define CFG_TUH_MAX_CABLES 16
+#endif
+#ifndef CFG_TUH_MIDI_RX_BUFSIZE
+  #define CFG_TUH_MIDI_RX_BUFSIZE USBH_EPSIZE_BULK_MAX
+#endif
+#ifndef CFG_TUH_MIDI_TX_BUFSIZE
+  #define CFG_TUH_MIDI_TX_BUFSIZE USBH_EPSIZE_BULK_MAX
+#endif
+#ifndef CFG_TUH_MIDI_EP_BUFSIZE
+  #define CFG_TUH_MIDI_EP_BUFSIZE USBH_EPSIZE_BULK_MAX
+#endif
+
+#define MIDI_MAX_DATA_VAL 0x7f
+static struct midih_limits_s {
+    size_t midi_rx_buf;
+    size_t midi_tx_buf;
+    uint8_t max_cables;
+} midih_limits = {CFG_TUH_MIDI_RX_BUFSIZE, CFG_TUH_MIDI_TX_BUFSIZE, CFG_TUH_MAX_CABLES};
+
+// This descriptor follows the standard bulk data endpoint descriptor
+typedef struct
+{
+  uint8_t bLength            ; ///< Size of this descriptor in bytes (4+bNumEmbMIDIJack)
+  uint8_t bDescriptorType    ; ///< Descriptor Type, must be CS_ENDPOINT
+  uint8_t bDescriptorSubType ; ///< Descriptor SubType, must be MS_GENERAL
+  uint8_t bNumEmbMIDIJack;   ; ///< Number of embedded MIDI jacks associated with this endpoint
+  uint8_t baAssocJackID[];   ; ///< A list of associated jacks
+} midi_cs_desc_endpoint_t;
+
+typedef struct
+{
+  uint8_t buffer[4];
+  uint8_t index;
+  uint8_t total;
+}midi_stream_t;
+
+typedef struct
+{
+  uint8_t dev_addr;
+  uint8_t itf_num;
+
+  uint8_t ep_in;          // IN endpoint address
+  uint8_t ep_out;         // OUT endpoint address
+  uint16_t ep_in_max;     // min( midih_limits.midi_rx_buf, wMaxPacketSize of the IN endpoint)
+  uint16_t ep_out_max;    //  min( midih_limits.midi_tx_buf, wMaxPacketSize of the OUT endpoint)
+
+  uint8_t num_cables_rx;  // IN endpoint CS descriptor bNumEmbMIDIJack value
+  uint8_t num_cables_tx;  // OUT endpoint CS descriptor bNumEmbMIDIJack value
+
+  // For Stream read()/write() API
+  // Messages are always 4 bytes long, queue them for reading and writing so the
+  // callers can use the Stream interface with single-byte read/write calls.
+  midi_stream_t *stream_write;
+  midi_stream_t stream_read;
+
+  /*------------- From this point, data is not cleared by bus reset -------------*/
+  // Endpoint FIFOs
+  tu_fifo_t rx_ff;
+  tu_fifo_t tx_ff;
+ 
+
+  uint8_t *rx_ff_buf;
+  uint8_t *tx_ff_buf;
+
+  #if CFG_FIFO_MUTEX
+  osal_mutex_def_t rx_ff_mutex;
+  osal_mutex_def_t tx_ff_mutex;
+  #endif
+
+  // Endpoint Transfer buffer
+  CFG_TUSB_MEM_ALIGN uint8_t epout_buf[CFG_TUH_MIDI_EP_BUFSIZE];
+  CFG_TUSB_MEM_ALIGN uint8_t epin_buf[CFG_TUH_MIDI_EP_BUFSIZE];
+
+  bool configured;
+  // Track the transfer result in the xfer_cb function
+  // If the result is not XFER_RESULT_SUCCESS, block
+  // midih_flush() and do not restart IN polling.
+  // The user will need to unplug and re-plug the device
+  xfer_result_t last_xfer_result;
+#if CFG_MIDI_HOST_DEVSTRINGS
+#define MAX_STRING_INDICES 32
+  uint8_t all_string_indices[MAX_STRING_INDICES];
+  uint8_t num_string_indices;
+#define MAX_IN_JACKS 8
+#define MAX_OUT_JACKS 8
+  struct {
+    uint8_t jack_id;
+    uint8_t jack_type;
+    uint8_t string_index;
+  } in_jack_info[MAX_IN_JACKS];
+  uint8_t next_in_jack;
+  struct {
+    uint8_t jack_id;
+    uint8_t jack_type;
+    uint8_t num_source_ids;
+    uint8_t source_ids[MAX_IN_JACKS/4];
+    uint8_t string_index;
+  } out_jack_info[MAX_OUT_JACKS];
+  uint8_t next_out_jack;
+  uint8_t ep_in_associated_jacks[MAX_OUT_JACKS/2];
+  uint8_t ep_out_associated_jacks[MAX_IN_JACKS/2];
+#endif
+}midih_interface_t;
+
+static midih_interface_t _midi_host[CFG_TUH_DEVICE_MAX];
+
+static midih_interface_t *get_midi_host(uint8_t dev_addr)
+{
+  TU_VERIFY(dev_addr >0 && dev_addr <= CFG_TUH_DEVICE_MAX);
+  return (_midi_host + dev_addr - 1);
+}
+
+//------------- Internal prototypes -------------//
+static uint32_t write_flush(uint8_t dev_addr, midih_interface_t* midi);
+
+static void midih_freeall(void)
+{
+  // free memory allocated by midih_init()
+  for (int inst = 0; inst < CFG_TUH_DEVICE_MAX; inst++)
+  {
+    midih_interface_t *p_midi_host = &_midi_host[inst];
+    if (p_midi_host->rx_ff_buf != NULL)
+    {
+      free (p_midi_host->rx_ff_buf);
+      p_midi_host->rx_ff_buf = NULL;
+    }
+    if (p_midi_host->tx_ff_buf != NULL)
+    {
+      free (p_midi_host->tx_ff_buf);
+      p_midi_host->tx_ff_buf = NULL;
+    }
+    if (p_midi_host->stream_write != NULL)
+    {
+      free(p_midi_host->stream_write);
+      p_midi_host->stream_write = NULL;
+    }
+  }
+}
+
+//--------------------------------------------------------------------+
+// USBH API
+//--------------------------------------------------------------------+
+void tuh_midih_define_limits(size_t midi_rx_buffer_bytes, size_t midi_tx_buffer_bytes, uint8_t max_cables)
+{
+  // prevent memory leak in case midih_init() was called before this function
+  midih_freeall();
+  midih_limits.midi_rx_buf = midi_rx_buffer_bytes;
+  midih_limits.midi_tx_buf = midi_tx_buffer_bytes;
+  midih_limits.max_cables = max_cables;
+}
+
+bool midih_init(void)
+{
+  tu_memclr(&_midi_host, sizeof(_midi_host));
+  // config fifos
+  for (int inst = 0; inst < CFG_TUH_DEVICE_MAX; inst++)
+  {
+    midih_interface_t *p_midi_host = &_midi_host[inst];
+    p_midi_host->rx_ff_buf = malloc(midih_limits.midi_rx_buf);
+    p_midi_host->tx_ff_buf = malloc(midih_limits.midi_tx_buf);
+    p_midi_host->stream_write = malloc(midih_limits.max_cables * sizeof(midi_stream_t));
+    TU_ASSERT((p_midi_host->rx_ff_buf != NULL && p_midi_host->tx_ff_buf != NULL && p_midi_host->stream_write != NULL), 0);
+    tu_memclr(p_midi_host->stream_write, sizeof(*(p_midi_host->stream_write))*midih_limits.max_cables);
+    tu_fifo_config(&p_midi_host->rx_ff, p_midi_host->rx_ff_buf, midih_limits.midi_rx_buf, 1, false); // true, true
+    tu_fifo_config(&p_midi_host->tx_ff, p_midi_host->tx_ff_buf, midih_limits.midi_tx_buf, 1, false); // OBVS.
+
+  #if CFG_FIFO_MUTEX
+    tu_fifo_config_mutex(&p_midi_host->rx_ff, NULL, osal_mutex_create(&p_midi_host->rx_ff_mutex));
+    tu_fifo_config_mutex(&p_midi_host->tx_ff, osal_mutex_create(&p_midi_host->tx_ff_mutex), NULL);
+  #endif
+  }
+  return true;
+}
+
+bool midih_deinit()
+{
+  midih_freeall();
+  return true;
+}
+bool midih_xfer_cb(uint8_t dev_addr, uint8_t ep_addr, xfer_result_t result, uint32_t xferred_bytes)
+{
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  TU_VERIFY(p_midi_host != NULL);
+  p_midi_host->last_xfer_result = result;
+  if (result == XFER_RESULT_FAILED) {
+    TU_LOG2("MIDIH xfer result failed\r\n");
+    return false;
+  }
+  TU_ASSERT(result == XFER_RESULT_SUCCESS);
+
+  if ( ep_addr == p_midi_host->ep_in)
+  {
+    // receive new data if available
+    uint32_t packets_queued = 0;
+    if (xferred_bytes)
+    {
+      // put in the RX FIFO only non-zero MIDI IN 4-byte packets
+      uint8_t* buf = p_midi_host->epin_buf;
+      uint32_t npackets = xferred_bytes / 4;
+      uint32_t packet_num;
+      for (packet_num = 0; packet_num < npackets; packet_num++)
+      {
+        // some devices send back all zero packets even if there is no data ready
+        uint32_t packet = (uint32_t)((*buf)<<24) | ((uint32_t)(*(buf+1))<<16) | ((uint32_t)(*(buf+2))<<8) | ((uint32_t)(*(buf+3)));
+        if (packet != 0)
+        {
+          tu_fifo_write_n(&p_midi_host->rx_ff, buf, 4);
+          ++packets_queued;
+          TU_LOG3("MIDI RX=%08lx\r\n", packet);
+        }
+        buf += 4;
+      }
+      // invoke receive callback if available
+      if (tuh_midi_rx_cb && packets_queued)
+      {
+        tuh_midi_rx_cb(dev_addr, packets_queued);
+      }
+    }
+
+    TU_LOG2("Requesting poll IN endpoint %d\r\n", p_midi_host->ep_in);
+    TU_ASSERT(usbh_edpt_xfer(p_midi_host->dev_addr, p_midi_host->ep_in, p_midi_host->epin_buf, p_midi_host->ep_in_max), 0);
+  }
+  else if ( ep_addr == p_midi_host->ep_out )
+  {
+    if (0 == write_flush(dev_addr, p_midi_host))
+    {
+      // If there is no data left, a ZLP should be sent if
+      // xferred_bytes is multiple of EP size and not zero
+      if ( !tu_fifo_count(&p_midi_host->tx_ff) && xferred_bytes && (0 == (xferred_bytes % p_midi_host->ep_out_max)) )
+      {
+        if ( usbh_edpt_claim(dev_addr, p_midi_host->ep_out) )
+        {
+          TU_ASSERT(usbh_edpt_xfer(dev_addr, p_midi_host->ep_out, XFER_RESULT_SUCCESS, 0));
+        }
+      }
+    }
+    if (tuh_midi_tx_cb)
+    {
+      tuh_midi_tx_cb(dev_addr);
+    }
+  }
+
+  return true;
+}
+
+void midih_close(uint8_t dev_addr)
+{
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  if (p_midi_host == NULL)
+    return;
+  if (tuh_midi_umount_cb)
+    tuh_midi_umount_cb(dev_addr, 0);
+  tu_fifo_clear(&p_midi_host->rx_ff);
+  tu_fifo_clear(&p_midi_host->tx_ff);
+  p_midi_host->ep_in = 0;
+  p_midi_host->ep_in_max = 0;
+  p_midi_host->ep_out = 0;
+  p_midi_host->ep_out_max = 0;
+  p_midi_host->itf_num = 0;
+  p_midi_host->num_cables_rx = 0;
+  p_midi_host->num_cables_tx = 0;
+  p_midi_host->dev_addr = 255; // invalid
+  p_midi_host->configured = false;
+  tu_memclr(&p_midi_host->stream_read, sizeof(p_midi_host->stream_read));
+  tu_memclr(p_midi_host->stream_write, sizeof(p_midi_host->stream_write)*midih_limits.max_cables);
+}
+
+//--------------------------------------------------------------------+
+// Enumeration
+//--------------------------------------------------------------------+
+bool midih_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_interface_t const *desc_itf, uint16_t max_len)
+{
+  (void) rhport;
+
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+
+  TU_VERIFY(p_midi_host != NULL);
+  p_midi_host->last_xfer_result = XFER_RESULT_SUCCESS;
+#if CFG_MIDI_HOST_DEVSTRINGS
+  p_midi_host->num_string_indices = 0;
+#endif
+  TU_VERIFY(TUSB_CLASS_AUDIO == desc_itf->bInterfaceClass);
+  // There can be just a MIDI interface or an audio and a MIDI interface. Only open the MIDI interface
+  uint8_t const *p_desc = (uint8_t const *) desc_itf;
+  uint16_t len_parsed = 0;
+  if (AUDIO_SUBCLASS_CONTROL == desc_itf->bInterfaceSubClass)
+  {
+#if CFG_MIDI_HOST_DEVSTRINGS
+    // Keep track of any string descriptor that might be here
+    if (desc_itf->iInterface != 0)
+        p_midi_host->all_string_indices[p_midi_host->num_string_indices++] = desc_itf->iInterface;
+#endif
+    // This driver does not support audio streaming. However, if this is the audio control interface
+    // there might be a MIDI interface following it. Search through every descriptor until a MIDI
+    // interface is found or the end of the descriptor is found
+    while (len_parsed < max_len && (desc_itf->bInterfaceClass != TUSB_CLASS_AUDIO || desc_itf->bInterfaceSubClass != AUDIO_SUBCLASS_MIDI_STREAMING))
+    {
+      len_parsed += desc_itf->bLength;
+      p_desc = tu_desc_next(p_desc);
+      desc_itf = (tusb_desc_interface_t const *)p_desc;
+    }
+
+    TU_VERIFY(TUSB_CLASS_AUDIO == desc_itf->bInterfaceClass);
+  }
+  TU_VERIFY(AUDIO_SUBCLASS_MIDI_STREAMING == desc_itf->bInterfaceSubClass);
+  len_parsed += desc_itf->bLength;
+
+#if CFG_MIDI_HOST_DEVSTRINGS
+  // Keep track of any string descriptor that might be here
+  if (desc_itf->iInterface != 0)
+      p_midi_host->all_string_indices[p_midi_host->num_string_indices++] = desc_itf->iInterface;
+#endif
+  p_desc = tu_desc_next(p_desc);
+  TU_LOG1("MIDI opening Interface %u (addr = %u)\r\n", desc_itf->bInterfaceNumber, dev_addr);
+  // Find out if getting the MIDI class specific interface header or an endpoint descriptor
+  // or a class-specific endpoint descriptor
+  // Jack descriptors or element descriptors must follow the cs interface header,
+  // but this driver does not support devices that contain element descriptors
+
+  // assume it is an interface header
+  midi_desc_header_t const *p_mdh = (midi_desc_header_t const *)p_desc;
+  TU_VERIFY((p_mdh->bDescriptorType == TUSB_DESC_CS_INTERFACE && p_mdh->bDescriptorSubType == MIDI_CS_INTERFACE_HEADER) || 
+    (p_mdh->bDescriptorType == TUSB_DESC_CS_ENDPOINT && p_mdh->bDescriptorSubType == MIDI_CS_ENDPOINT_GENERAL) ||
+    p_mdh->bDescriptorType == TUSB_DESC_ENDPOINT);
+
+  uint8_t prev_ep_addr = 0; // the CS endpoint descriptor is associated with the previous endpoint descrptor
+  p_midi_host->itf_num = desc_itf->bInterfaceNumber;
+  tusb_desc_endpoint_t const* in_desc = NULL;
+  tusb_desc_endpoint_t const* out_desc = NULL;
+  while (len_parsed < max_len)
+  {
+    TU_VERIFY((p_mdh->bDescriptorType == TUSB_DESC_CS_INTERFACE) || 
+      (p_mdh->bDescriptorType == TUSB_DESC_CS_ENDPOINT && p_mdh->bDescriptorSubType == MIDI_CS_ENDPOINT_GENERAL) ||
+      p_mdh->bDescriptorType == TUSB_DESC_ENDPOINT);
+
+    if (p_mdh->bDescriptorType == TUSB_DESC_CS_INTERFACE) {
+      // The USB host doesn't really need this information unless it uses
+      // the string descriptor for a jack or Element
+
+      // assume it is an input jack
+      midi_desc_in_jack_t const *p_mdij = (midi_desc_in_jack_t const *)p_desc;
+      if (p_mdij->bDescriptorSubType == MIDI_CS_INTERFACE_HEADER)
+      {
+        TU_LOG2("Found MIDI Interface Header\r\b");
+      }
+      else if (p_mdij->bDescriptorSubType == MIDI_CS_INTERFACE_IN_JACK)
+      {
+        // Then it is an in jack. 
+        TU_LOG2("Found in jack\r\n");
+#if CFG_MIDI_HOST_DEVSTRINGS
+        if (p_midi_host->next_in_jack < MAX_IN_JACKS)
+        {
+          p_midi_host->in_jack_info[p_midi_host->next_in_jack].jack_id = p_mdij->bJackID;
+          p_midi_host->in_jack_info[p_midi_host->next_in_jack].jack_type = p_mdij->bJackType;
+          p_midi_host->in_jack_info[p_midi_host->next_in_jack].string_index = p_mdij->iJack;
+          ++p_midi_host->next_in_jack;
+          // Keep track of any string descriptor that might be here
+          if (p_mdij->iJack != 0)
+            p_midi_host->all_string_indices[p_midi_host->num_string_indices++] = p_mdij->iJack;
+
+        }
+#endif
+      }
+      else if (p_mdij->bDescriptorSubType == MIDI_CS_INTERFACE_OUT_JACK)
+      {
+        // then it is an out jack
+        TU_LOG2("Found out jack\r\n");
+#if CFG_MIDI_HOST_DEVSTRINGS
+        if (p_midi_host->next_out_jack < MAX_OUT_JACKS)
+        {
+          midi_desc_out_jack_t const *p_mdoj = (midi_desc_out_jack_t const *)p_desc;
+          p_midi_host->out_jack_info[p_midi_host->next_out_jack].jack_id = p_mdoj->bJackID;
+          p_midi_host->out_jack_info[p_midi_host->next_out_jack].jack_type = p_mdoj->bJackType;
+          p_midi_host->out_jack_info[p_midi_host->next_out_jack].num_source_ids = p_mdoj->bNrInputPins;
+          const struct associated_jack_s {
+              uint8_t id;
+              uint8_t pin;
+          } *associated_jack = (const struct associated_jack_s *)(p_desc+6);
+          int jack;
+          for (jack = 0; jack < p_mdoj->bNrInputPins; jack++)
+          {
+            p_midi_host->out_jack_info[p_midi_host->next_out_jack].source_ids[jack] = associated_jack->id;
+          }
+          p_midi_host->out_jack_info[p_midi_host->next_out_jack].string_index = *(p_desc+6+p_mdoj->bNrInputPins*2);
+          ++p_midi_host->next_out_jack;
+          if (p_mdoj->iJack != 0)
+            p_midi_host->all_string_indices[p_midi_host->num_string_indices++] = p_mdoj->iJack;
+        }
+#endif
+      }
+      else if (p_mdij->bDescriptorSubType == MIDI_CS_INTERFACE_ELEMENT)
+      {
+        // the it is an element;
+    #if CFG_MIDI_HOST_DEVSTRINGS
+        TU_LOG1("Found element; strings not supported\r\n");
+    #else
+        TU_LOG2("Found element\r\n");
+    #endif
+      }
+      else
+      {
+        TU_LOG2("Unknown CS Interface sub-type %u\r\n", p_mdij->bDescriptorSubType);
+        TU_VERIFY(false); // unknown CS Interface sub-type
+      }
+      len_parsed += p_mdij->bLength;
+    }
+    else if (p_mdh->bDescriptorType == TUSB_DESC_CS_ENDPOINT)
+    {
+      TU_LOG2("found CS_ENDPOINT Descriptor for %02x\r\n", prev_ep_addr);
+      TU_VERIFY(prev_ep_addr != 0);
+      // parse out the mapping between the device's embedded jacks and the endpoints
+      // Each embedded IN jack is assocated with an OUT endpoint
+      midi_cs_desc_endpoint_t const* p_csep = (midi_cs_desc_endpoint_t const*)p_mdh;
+      if (tu_edpt_dir(prev_ep_addr) == TUSB_DIR_OUT)
+      {
+        TU_VERIFY(p_midi_host->ep_out == prev_ep_addr);
+        TU_VERIFY(p_midi_host->num_cables_tx == 0);
+        p_midi_host->num_cables_tx = p_csep->bNumEmbMIDIJack;
+#if CFG_MIDI_HOST_DEVSTRINGS
+        uint8_t jack;
+        uint8_t max_jack = p_midi_host->num_cables_tx;
+        if (max_jack > sizeof(p_midi_host->ep_out_associated_jacks))
+        {
+            max_jack = sizeof(p_midi_host->ep_out_associated_jacks);
+        }
+        for (jack = 0; jack < max_jack; jack++)
+        {
+          p_midi_host->ep_out_associated_jacks[jack] = p_csep->baAssocJackID[jack];
+        }
+#endif
+      }
+      else
+      {
+        TU_VERIFY(p_midi_host->ep_in == prev_ep_addr);
+        TU_VERIFY(p_midi_host->num_cables_rx == 0);
+        p_midi_host->num_cables_rx = p_csep->bNumEmbMIDIJack;
+#if CFG_MIDI_HOST_DEVSTRINGS
+        uint8_t jack;
+        uint8_t max_jack = p_midi_host->num_cables_rx;
+        if (max_jack > sizeof(p_midi_host->ep_in_associated_jacks))
+        {
+            max_jack = sizeof(p_midi_host->ep_in_associated_jacks);
+        }
+        for (jack = 0; jack < max_jack; jack++)
+        {
+          p_midi_host->ep_in_associated_jacks[jack] = p_csep->baAssocJackID[jack];
+        }
+#endif
+      }
+      len_parsed += p_csep->bLength;
+      prev_ep_addr = 0;
+    }
+    else if (p_mdh->bDescriptorType == TUSB_DESC_ENDPOINT) {
+      // parse out the bulk endpoint info
+      tusb_desc_endpoint_t *p_ep = (tusb_desc_endpoint_t *)p_mdh;
+      TU_LOG2("found ENDPOINT Descriptor %02x\r\n", p_ep->bEndpointAddress);
+      if (p_ep->wMaxPacketSize > USBH_EPSIZE_BULK_MAX) {
+        TU_LOG2("ENDPOINT %02x wMaxPacketSize shorted from %u to %u\r\n", p_ep->bEndpointAddress, p_ep->wMaxPacketSize, USBH_EPSIZE_BULK_MAX);
+        p_ep->wMaxPacketSize = USBH_EPSIZE_BULK_MAX;
+      }
+      if (tu_edpt_dir(p_ep->bEndpointAddress) == TUSB_DIR_OUT)
+      {
+        TU_VERIFY(p_midi_host->ep_out == 0);
+        TU_VERIFY(p_midi_host->num_cables_tx == 0);
+        p_midi_host->ep_out = p_ep->bEndpointAddress;
+        p_midi_host->ep_out_max = p_ep->wMaxPacketSize;
+        if (p_midi_host->ep_out_max > midih_limits.midi_tx_buf)
+          p_midi_host->ep_out_max = midih_limits.midi_tx_buf;
+        prev_ep_addr = p_midi_host->ep_out;
+        out_desc = p_ep;
+      }
+      else
+      {
+        TU_VERIFY(p_midi_host->ep_in == 0);
+        TU_VERIFY(p_midi_host->num_cables_rx == 0);
+        p_midi_host->ep_in = p_ep->bEndpointAddress;
+        p_midi_host->ep_in_max = p_ep->wMaxPacketSize;
+        if (p_midi_host->ep_in_max > midih_limits.midi_rx_buf)
+          p_midi_host->ep_in_max = midih_limits.midi_rx_buf;
+        prev_ep_addr = p_midi_host->ep_in;
+        in_desc = p_ep;
+      }
+      len_parsed += p_mdh->bLength;
+    }
+    p_desc = tu_desc_next(p_desc);
+    p_mdh = (midi_desc_header_t const *)p_desc;
+  }
+  TU_VERIFY((p_midi_host->ep_out != 0 && p_midi_host->num_cables_tx != 0) ||
+            (p_midi_host->ep_in != 0 && p_midi_host->num_cables_rx != 0));
+  TU_LOG1("MIDI descriptor parsed successfully\r\n");
+#if CFG_MIDI_HOST_DEVSTRINGS
+  // remove duplicate string indices
+  for (int idx=0; idx < p_midi_host->num_string_indices; idx++) {
+      for (int jdx = idx+1; jdx < p_midi_host->num_string_indices; jdx++) {
+          while (jdx < p_midi_host->num_string_indices &&  p_midi_host->all_string_indices[idx] == p_midi_host->all_string_indices[jdx]) {
+              // delete the duplicate by overwriting it with the last entry and reducing the number of entries by 1
+              p_midi_host->all_string_indices[jdx] = p_midi_host->all_string_indices[p_midi_host->num_string_indices-1];
+              --p_midi_host->num_string_indices;
+          }
+      }
+  }
+#endif
+  if (in_desc)
+  {
+    TU_ASSERT(tuh_edpt_open(dev_addr, in_desc));
+    // Some devices always return exactly the request length so transfers won't complete
+    // unless you assume every transfer is the last one.
+    // TODO usbh_edpt_force_last_buffer(dev_addr, p_midi_host->ep_in, true);
+  }
+  if (out_desc)
+  {
+    TU_ASSERT(tuh_edpt_open(dev_addr, out_desc));
+  }
+  p_midi_host->dev_addr = dev_addr;
+
+  return true;
+}
+
+bool tuh_midi_configured(uint8_t dev_addr)
+{
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  TU_VERIFY(p_midi_host != NULL);
+  return p_midi_host->configured;
+}
+
+bool midih_set_config(uint8_t dev_addr, uint8_t itf_num)
+{
+  (void) itf_num;
+  TU_LOG2("Set config dev_addr=%u\r\n", dev_addr);
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  TU_VERIFY(p_midi_host != NULL);
+  p_midi_host->configured = true;
+
+  TU_LOG2("Requesting poll IN endpoint %d\r\n", p_midi_host->ep_in);
+  TU_ASSERT(usbh_edpt_xfer(p_midi_host->dev_addr, p_midi_host->ep_in, p_midi_host->epin_buf, p_midi_host->ep_in_max), 0);
+  if (tuh_midi_mount_cb)
+  {
+    tuh_midi_mount_cb(dev_addr, p_midi_host->ep_in, p_midi_host->ep_out, p_midi_host->num_cables_rx, p_midi_host->num_cables_tx);
+  }
+  usbh_driver_set_config_complete(dev_addr, itf_num);
+  return true;
+}
+
+//--------------------------------------------------------------------+
+// Stream API
+//--------------------------------------------------------------------+
+static uint32_t write_flush(uint8_t dev_addr, midih_interface_t* midi)
+{
+  // No data to send
+  if ( !tu_fifo_count(&midi->tx_ff) ) return 0;
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  TU_VERIFY(p_midi_host != NULL);
+  if (p_midi_host->last_xfer_result != XFER_RESULT_SUCCESS) return 0;
+
+  // skip if previous transfer not complete
+  TU_VERIFY( usbh_edpt_claim(dev_addr, midi->ep_out) );
+
+  uint16_t count = tu_fifo_read_n(&midi->tx_ff, midi->epout_buf, midi->ep_out_max);
+
+  if (count)
+  {
+    TU_ASSERT( usbh_edpt_xfer(dev_addr, midi->ep_out, midi->epout_buf, count), 0 );
+    return count;
+  }else
+  {
+    // Release endpoint since we don't make any transfer
+    usbh_edpt_release(dev_addr, midi->ep_out);
+    return 0;
+  }
+}
+
+bool tuh_midi_can_write_stream (uint8_t dev_addr)
+{
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  return (tu_fifo_remaining(&p_midi_host->tx_ff) >= 4);
+}
+
+uint32_t tuh_midi_stream_write (uint8_t dev_addr, uint8_t cable_num, uint8_t const* buffer, uint32_t bufsize)
+{
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  TU_VERIFY(p_midi_host != NULL);
+  TU_VERIFY(cable_num < p_midi_host->num_cables_tx);
+  TU_VERIFY(cable_num < midih_limits.max_cables);
+  midi_stream_t *stream = &p_midi_host->stream_write[cable_num];
+
+  uint32_t i = 0;
+  uint8_t const CN_ = cable_num << 4;
+
+  while ( (i < bufsize) && (tu_fifo_remaining(&p_midi_host->tx_ff) >= 4) )
+  {
+    uint8_t const data = buffer[i];
+    i++;
+
+    if (data >= MIDI_STATUS_SYSREAL_TIMING_CLOCK)
+    {
+        // real-time messages need to be sent right away
+        midi_stream_t streamrt;
+        streamrt.buffer[0] = CN_ + MIDI_CIN_1BYTE_DATA;
+        streamrt.buffer[1] = data;
+        streamrt.buffer[2] = 0;
+        streamrt.buffer[3] = 0;
+
+        uint16_t const count = tu_fifo_write_n(&p_midi_host->tx_ff, streamrt.buffer, 4);
+        // FIFO overflown, since we already check fifo remaining. It is probably race condition
+        TU_ASSERT(count == 4, i);
+    }
+    else if ( stream->index == 0 )
+    {
+      //------------- New event packet -------------//
+
+      uint8_t const msg = data >> 4;
+      uint8_t const _msg = (stream->buffer[0]) & 0x0F;
+      stream->index = 2;
+      //stream->buffer[1] = data; //first check if its a running status byte, then update
+      stream->total = 4;
+
+      // Check to see if we're still in a SysEx transmit.
+      if ( _msg == MIDI_CIN_SYSEX_START)
+      {
+        stream->buffer[1] = data;
+
+        if ( data == MIDI_STATUS_SYSEX_END )
+        {
+          stream->buffer[0] = CN_ + MIDI_CIN_SYSEX_END_1BYTE;
+          stream->total = 2;
+        }
+      }
+      else if (msg < 0x8 && _msg >= 0x8 && _msg < 0xF)   //Running Status ?
+      {
+        //stream->buffer[0] leave;
+        //stream->buffer[1] leave;
+        stream->buffer[2] = data;
+
+        if (_msg < 0xC || _msg == 0xE)
+        {
+            stream->index = 3;
+        }
+        else    //if (_msg < 0xF)
+        {
+            stream->index = 3;
+            stream->total = 3;
+        }
+      }
+      else if ( (msg >= 0x8 && msg <= 0xB) || msg == 0xE )
+      {
+        // Channel Voice Messages
+        stream->buffer[1] = data;
+        stream->buffer[0] = CN_ + msg;
+      }
+      else if ( msg == 0xC || msg == 0xD)
+      {
+        // Channel Voice Messages, two-byte variants (Program Change and Channel Pressure)
+        stream->buffer[1] = data;
+        stream->buffer[0] = CN_ + msg;
+        stream->total = 3;
+      }
+      else if ( msg == 0xf )
+      {
+        // System message
+        stream->buffer[1] = data;
+
+        if ( data == MIDI_STATUS_SYSEX_START )
+        {
+          stream->buffer[0] = CN_ + MIDI_CIN_SYSEX_START;
+        }
+        else if ( data == MIDI_STATUS_SYSCOM_TIME_CODE_QUARTER_FRAME || data == MIDI_STATUS_SYSCOM_SONG_SELECT )
+        {
+          stream->buffer[0] = CN_ + MIDI_CIN_SYSCOM_2BYTE;
+          stream->total = 3;
+        }
+        else if ( data == MIDI_STATUS_SYSCOM_SONG_POSITION_POINTER )
+        {
+          stream->buffer[0] = CN_ + MIDI_CIN_SYSCOM_3BYTE;
+        }
+        else        //for example, MIDI_STATUS_SYSCOM_TUNE_REQUEST
+        {
+          stream->buffer[0] = CN_ + MIDI_CIN_1BYTE_DATA;
+          stream->total = 2;
+        }
+      }
+      else
+      {
+        // Pack individual bytes if we don't support packing them into words.
+        stream->buffer[1] = data;
+        stream->buffer[0] = CN_ + 0xF;
+        stream->index = 2;
+        stream->total = 2;
+      }
+    }   //End of: if (stream->index == 0)
+    else
+    {
+      //------------- On-going (buffering) packet -------------//
+
+      TU_ASSERT(stream->index < 4, i);
+      stream->buffer[stream->index] = data;
+      stream->index++;
+      // See if this byte ends a SysEx.
+      if ( stream->buffer[0] == CN_ + MIDI_CIN_SYSEX_START && data == MIDI_STATUS_SYSEX_END )
+      {
+        stream->buffer[0] = CN_ + MIDI_CIN_SYSEX_START + (stream->index - 1);   //END +1/+2/+3 Bytes
+        stream->total = stream->index;
+      }
+    }
+
+    // Send out packet
+    if ( stream->index >= 2 && stream->index >= stream->total )
+    {
+      //zeroes unused bytes
+      for(uint8_t idx = stream->total; idx < 4; idx++) stream->buffer[idx] = 0;
+      TU_LOG3_MEM(stream->buffer, 4, 2);
+
+      uint16_t const count = tu_fifo_write_n(&p_midi_host->tx_ff, stream->buffer, 4);
+
+      stream->index = 0;
+
+      // FIFO overflown, since we already check fifo remaining. It is probably race condition
+      TU_ASSERT(count == 4, i);
+    }
+  }
+
+  return i;
+}
+
+
+bool tuh_midi_packet_write (uint8_t dev_addr, uint8_t const packet[4])
+{
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  TU_VERIFY(p_midi_host != NULL);
+
+  if (tu_fifo_remaining(&p_midi_host->tx_ff) < 4)
+  {
+    return false;
+  }
+
+  tu_fifo_write_n(&p_midi_host->tx_ff, packet, 4);
+
+  return true;
+}
+
+uint32_t tuh_midi_stream_flush( uint8_t dev_addr )
+{
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  TU_VERIFY(p_midi_host != NULL);
+
+  uint32_t bytes_flushed = 0;
+  if (!usbh_edpt_busy(p_midi_host->dev_addr, p_midi_host->ep_out))
+  {
+    bytes_flushed = write_flush(dev_addr, p_midi_host);
+  }
+  return bytes_flushed;
+}
+//--------------------------------------------------------------------+
+// Helper
+//--------------------------------------------------------------------+
+uint8_t tuh_midih_get_num_tx_cables (uint8_t dev_addr)
+{
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  TU_VERIFY(p_midi_host != NULL);
+  TU_VERIFY(p_midi_host->ep_out != 0); // returns 0 if fails
+  return p_midi_host->num_cables_tx;
+}
+
+uint8_t tuh_midih_get_num_rx_cables (uint8_t dev_addr)
+{
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  TU_VERIFY(p_midi_host != NULL);
+  TU_VERIFY(p_midi_host->ep_in != 0); // returns 0 if fails
+  return p_midi_host->num_cables_rx;
+}
+
+bool tuh_midi_packet_read (uint8_t dev_addr, uint8_t packet[4])
+{
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  TU_VERIFY(p_midi_host != NULL);
+  TU_VERIFY(tu_fifo_count(&p_midi_host->rx_ff) >= 4);
+  return tu_fifo_read_n(&p_midi_host->rx_ff, packet, 4) == 4;
+}
+
+uint32_t tuh_midi_stream_read (uint8_t dev_addr, uint8_t *p_cable_num, uint8_t *p_buffer, uint16_t bufsize)
+{
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  TU_VERIFY(p_midi_host != NULL);
+  uint32_t bytes_buffered = 0;
+  TU_ASSERT(p_cable_num);
+  TU_ASSERT(p_buffer);
+  TU_ASSERT(bufsize);
+  uint8_t one_byte;
+  if (!tu_fifo_peek(&p_midi_host->rx_ff, &one_byte))
+  {
+    return 0;
+  }
+  *p_cable_num = (one_byte >> 4) & 0xf;
+  uint32_t nread = tu_fifo_read_n(&p_midi_host->rx_ff, p_midi_host->stream_read.buffer, 4);
+  static uint16_t cable_sysex_in_progress; // bit i is set if received MIDI_STATUS_SYSEX_START but not MIDI_STATUS_SYSEX_END
+  while (nread == 4 && bytes_buffered < bufsize)
+  {
+    *p_cable_num=(p_midi_host->stream_read.buffer[0] >> 4) & 0x0f;
+    uint8_t bytes_to_add_to_stream = 0;
+    if (*p_cable_num < p_midi_host->num_cables_rx)
+    {
+      // ignore the CIN field; too many devices out there encode this wrong
+      uint8_t status = p_midi_host->stream_read.buffer[1];
+      uint16_t cable_mask = (uint16_t) (1 << *p_cable_num);
+      if (status <= MIDI_MAX_DATA_VAL || status == MIDI_STATUS_SYSEX_START)
+      {
+        if (status == MIDI_STATUS_SYSEX_START)
+        {
+          cable_sysex_in_progress |= cable_mask;
+        }
+        // only add the packet if a sysex message is in progress
+        if (cable_sysex_in_progress & cable_mask)
+        {
+          ++bytes_to_add_to_stream;
+          uint8_t idx;
+          for (idx = 2; idx < 4; idx++)
+          {
+            if (p_midi_host->stream_read.buffer[idx] <= MIDI_MAX_DATA_VAL)
+            {
+              ++bytes_to_add_to_stream;
+            }
+            else if (p_midi_host->stream_read.buffer[idx] == MIDI_STATUS_SYSEX_END)
+            {
+              ++bytes_to_add_to_stream;
+              cable_sysex_in_progress &= (uint16_t) ~cable_mask;
+              idx = 4; // force the loop to exit; I hate break statements in loops
+            }
+          }
+        }
+      }
+      else if (status < MIDI_STATUS_SYSEX_START)
+      {
+        // then it is a channel message either three bytes or two
+        uint8_t fake_cin = (status & 0xf0) >> 4;
+        switch (fake_cin)
+        {
+          case MIDI_CIN_NOTE_OFF:
+          case MIDI_CIN_NOTE_ON:
+          case MIDI_CIN_POLY_KEYPRESS:
+          case MIDI_CIN_CONTROL_CHANGE:
+          case MIDI_CIN_PITCH_BEND_CHANGE:
+            bytes_to_add_to_stream = 3;
+            break;
+          case MIDI_CIN_PROGRAM_CHANGE:
+          case MIDI_CIN_CHANNEL_PRESSURE:
+            bytes_to_add_to_stream = 2;
+            break;
+          default:
+            break; // Should not get this
+        }
+        cable_sysex_in_progress &= (uint16_t)~cable_mask;
+      }
+      else if (status < MIDI_STATUS_SYSREAL_TIMING_CLOCK)
+      {
+        switch (status)
+        {
+          case MIDI_STATUS_SYSCOM_TIME_CODE_QUARTER_FRAME:
+          case MIDI_STATUS_SYSCOM_SONG_SELECT:
+            bytes_to_add_to_stream = 2;
+            break;
+          case MIDI_STATUS_SYSCOM_SONG_POSITION_POINTER:
+            bytes_to_add_to_stream = 3;
+            break;
+          case MIDI_STATUS_SYSCOM_TUNE_REQUEST:
+          case MIDI_STATUS_SYSEX_END:
+            bytes_to_add_to_stream = 1;
+            break;
+          default:
+            break;
+          cable_sysex_in_progress &= (uint16_t)~cable_mask;
+        }
+      }
+      else
+      {
+        // Real-time message: can be inserted into a sysex message,
+        // so do don't clear cable_sysex_in_progress bit
+        bytes_to_add_to_stream = 1;
+      }
+    }
+    uint8_t idx;
+    for (idx = 1; idx <= bytes_to_add_to_stream; idx++)
+    {
+      *p_buffer++ = p_midi_host->stream_read.buffer[idx];
+    }
+    bytes_buffered += bytes_to_add_to_stream;
+    nread = 0;
+    if (tu_fifo_peek(&p_midi_host->rx_ff, &one_byte))
+    {
+      uint8_t new_cable = (one_byte >> 4) & 0xf;
+      if (new_cable == *p_cable_num)
+      {
+        // still on the same cable. Continue reading the stream
+        nread = tu_fifo_read_n(&p_midi_host->rx_ff, p_midi_host->stream_read.buffer, 4);
+      }
+    }
+  }
+
+  return bytes_buffered;
+}
+
+uint8_t tuh_midi_get_num_rx_cables(uint8_t dev_addr)
+{
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  TU_VERIFY(p_midi_host != NULL);
+  uint8_t num_cables = 0;
+  if (p_midi_host)
+  {
+    num_cables = p_midi_host->num_cables_rx;
+  }
+  return num_cables;
+}
+
+uint8_t tuh_midi_get_num_tx_cables(uint8_t dev_addr)
+{
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  TU_VERIFY(p_midi_host != NULL);
+  uint8_t num_cables = 0;
+  if (p_midi_host)
+  {
+    num_cables = p_midi_host->num_cables_tx;
+  }
+  return num_cables;
+}
+
+#if CFG_MIDI_HOST_DEVSTRINGS
+static uint8_t find_string_index(midih_interface_t *ptr, uint8_t jack_id)
+{
+  uint8_t index = 0;
+  uint8_t assoc;
+  for (assoc = 0; index == 0 && assoc < ptr->next_in_jack; assoc++)
+  {
+    if (jack_id == ptr->in_jack_info[assoc].jack_id)
+    {
+      index = ptr->in_jack_info[assoc].string_index;
+    }
+  }
+  for (assoc = 0; index == 0 && assoc < ptr->next_out_jack; assoc++)
+  {
+    if (jack_id == ptr->out_jack_info[assoc].jack_id)
+    {
+      index = ptr->out_jack_info[assoc].string_index;
+    }
+  }
+  return index;
+}
+#endif
+
+#if CFG_MIDI_HOST_DEVSTRINGS
+uint8_t tuh_midi_get_rx_cable_istrings(uint8_t dev_addr, uint8_t* istrings, uint8_t max_istrings)
+{
+  uint8_t nstrings = 0;
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  TU_VERIFY(p_midi_host != NULL);
+  nstrings = p_midi_host->num_cables_rx;
+  if (nstrings > max_istrings)
+  {
+      nstrings = max_istrings;
+  }
+  uint8_t jack;
+  for (jack=0; jack<nstrings; jack++)
+  {
+    uint8_t jack_id = p_midi_host->ep_in_associated_jacks[jack];
+    istrings[jack] = find_string_index(p_midi_host, jack_id);
+  }
+  return nstrings;
+}
+
+uint8_t tuh_midi_get_tx_cable_istrings(uint8_t dev_addr, uint8_t* istrings, uint8_t max_istrings)
+{
+  uint8_t nstrings = 0;
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  TU_VERIFY(p_midi_host != NULL);
+  nstrings = p_midi_host->num_cables_tx;
+  if (nstrings > max_istrings)
+  {
+      nstrings = max_istrings;
+  }
+  uint8_t jack;
+  for (jack=0; jack<nstrings; jack++)
+  {
+    uint8_t jack_id = p_midi_host->ep_out_associated_jacks[jack];
+    istrings[jack] = find_string_index(p_midi_host, jack_id);
+  }
+  return nstrings;
+}
+
+uint8_t tuh_midi_get_all_istrings(uint8_t dev_addr, const uint8_t** istrings)
+{
+  midih_interface_t *p_midi_host = get_midi_host(dev_addr);
+  TU_VERIFY(p_midi_host != NULL);
+  uint8_t nstrings = p_midi_host->num_string_indices;
+  if (nstrings)
+    *istrings = p_midi_host->all_string_indices;
+  return nstrings;
+}
+#endif
+#endif

--- a/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/examples/midi_host/usb_midi_host.h
+++ b/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/examples/midi_host/usb_midi_host.h
@@ -1,0 +1,172 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 rppicomidi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#ifndef _TUSB_MIDI_HOST_H_
+#define _TUSB_MIDI_HOST_H_
+
+#include "class/audio/audio.h"
+#include "class/midi/midi.h"
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+//--------------------------------------------------------------------+
+// Class Driver Configuration
+//--------------------------------------------------------------------+
+// Use this function in Arduino or other environments where modifying
+// the tusb_config.h file is not practical.
+// Call this before midih_init() gets called by the TinyUSB stack,
+// which is before the application calls tusb_init() or tuh_init().
+// Calling this function after midih_init() will cause problems.
+//
+// Note: To figure out how long a USB MIDI 1.0 stream needs to be
+// in bytes, multiply the number of bytes in the stream by 4/3 and
+// round up to the nearest 4 bytes.
+// For exampe, to send a 146 byte SysEx message, 146*4/3 = 194.66...
+// The next nearest 4 byte boundary is 196. So the buffer is 196 bytes,
+// or 49 4-byte USB MIDI packets.
+//
+// Parameters:
+// midi_rx_buffer_bytes is the number of bytes the USB Host can buffer
+// from the device. This has to be at least equal to the maximum bulk
+// transfer size of 64 bytes, but it is a good idea to set this to
+// at least the maximum SysEx message size in MIDI packets to improve
+// throughput.
+//
+// midi_tx_buffer_bytes is the maximum number of bytes the application
+// can write out to the interface in a single transaction. This should
+// be at least as large as the maximum bulk transfer size of 64 bytes.
+// To send long SysEx messages, you should make this buffer at least as
+// long as the longest message in MIDI packets or else SysEx message
+// writes may get truncated.
+//
+// max_cables defaults to 16. If you know you only need to convert
+// serial MIDI data to USB MIDI packets from cable numbers 0:N,
+// and N is less than 15, you can save a small amount
+// if RAM if you set this value to something less than 16.
+// For example, if your application is to convert a single
+// Serial Port MIDI to USB, then the highest cable number
+// is 0, so you only need one virtual cable. You will save the
+// deserialization buffer for 15 virtual cables (about 90 bytes).
+//
+void tuh_midih_define_limits(size_t midi_rx_buffer_bytes, size_t midi_tx_buffer_bytes, uint8_t max_cables);
+
+#ifndef CFG_MIDI_HOST_DEVSTRINGS
+#ifdef ARDUINO
+#define CFG_MIDI_HOST_DEVSTRINGS 1
+#else
+#define CFG_MIDI_HOST_DEVSTRINGS 0
+#endif
+#endif
+
+//--------------------------------------------------------------------+
+// Application API (Single Interface)
+//--------------------------------------------------------------------+
+
+bool     tuh_midi_configured      (uint8_t dev_addr);
+
+// return the number of virtual midi cables on the device's OUT endpoint
+uint8_t tuh_midih_get_num_tx_cables (uint8_t dev_addr);
+
+// return the number of virtual midi cables on the device's IN endpoint
+uint8_t tuh_midih_get_num_rx_cables (uint8_t dev_addr);
+
+// Queue a packet to the device. The application
+// must call tuh_midi_stream_flush to actually have the
+// data go out. It is up to the application to properly
+// format this packet; this function does not check.
+// Using this function with tuh_midi_stream_write()
+// might produce undefined behavior.
+// Returns true if the packet was successfully queued.
+bool tuh_midi_packet_write (uint8_t dev_addr, uint8_t const packet[4]);
+
+// Queue a message to the device. The application
+// must call tuh_midi_stream_flush to actually have the
+// data go out. Note that cable_num must be < CFG_TUH_CABLE_MAX
+// (note CFG_TUH_CABLE_MAX default is 16)
+uint32_t tuh_midi_stream_write (uint8_t dev_addr, uint8_t cable_num, uint8_t const* p_buffer, uint32_t bufsize);
+
+/// Return true if the MIDI OUT FIFO has enough space for at
+/// least one more message
+bool tuh_midi_can_write_stream (uint8_t dev_addr);
+
+// Send any queued packets to the device if the host hardware is able to do it
+// Returns the number of bytes flushed to the host hardware or 0 if
+// the host hardware is busy or there is nothing in queue to send.
+uint32_t tuh_midi_stream_flush( uint8_t dev_addr);
+
+// Get the MIDI stream from the device. Set the value pointed
+// to by p_cable_num to the MIDI cable number intended to receive it.
+// The MIDI stream will be stored in the buffer pointed to by p_buffer.
+// Return the number of bytes added to the buffer.
+// Note that this function ignores the CIN field of the MIDI packet
+// because a number of commercial devices out there do not encode
+// it properly.
+uint32_t tuh_midi_stream_read (uint8_t dev_addr, uint8_t *p_cable_num, uint8_t *p_buffer, uint16_t bufsize);
+
+// Read a raw MIDI packet from the connected device
+// This function does not parse the packet format
+// Return true if a packet was returned
+bool tuh_midi_packet_read (uint8_t dev_addr, uint8_t packet[4]);
+
+uint8_t tuh_midi_get_num_rx_cables(uint8_t dev_addr);
+uint8_t tuh_midi_get_num_tx_cables(uint8_t dev_addr);
+#if CFG_MIDI_HOST_DEVSTRINGS
+uint8_t tuh_midi_get_rx_cable_istrings(uint8_t dev_addr, uint8_t* istrings, uint8_t max_istrings);
+uint8_t tuh_midi_get_tx_cable_istrings(uint8_t dev_addr, uint8_t* istrings, uint8_t max_istrings);
+uint8_t tuh_midi_get_all_istrings(uint8_t dev_addr, const uint8_t** istrings);
+#endif
+//--------------------------------------------------------------------+
+// Internal Class Driver API
+//--------------------------------------------------------------------+
+bool midih_init       (void);
+bool midih_deinit     (void);
+bool midih_open       (uint8_t rhport, uint8_t dev_addr, tusb_desc_interface_t const *desc_itf, uint16_t max_len);
+bool midih_set_config (uint8_t dev_addr, uint8_t itf_num);
+bool midih_xfer_cb    (uint8_t dev_addr, uint8_t ep_addr, xfer_result_t result, uint32_t xferred_bytes);
+void midih_close      (uint8_t dev_addr);
+
+//--------------------------------------------------------------------+
+// Callbacks (Weak is optional)
+//--------------------------------------------------------------------+
+
+// Invoked when device with MIDI interface is mounted.
+// If the MIDI host application requires MIDI IN, it should requst an
+// IN transfer here. The device will likely NAK this transfer. How the driver
+// handles the NAK is hardware dependent.
+TU_ATTR_WEAK void tuh_midi_mount_cb(uint8_t dev_addr, uint8_t in_ep, uint8_t out_ep, uint8_t num_cables_rx, uint16_t num_cables_tx);
+
+// Invoked when device with MIDI interface is un-mounted
+// For now, the instance parameter is always 0 and can be ignored
+TU_ATTR_WEAK void tuh_midi_umount_cb(uint8_t dev_addr, uint8_t instance);
+
+TU_ATTR_WEAK void tuh_midi_rx_cb(uint8_t dev_addr, uint32_t num_packets);
+TU_ATTR_WEAK void tuh_midi_tx_cb(uint8_t dev_addr);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _TUSB_MIDI_HOST_H_ */

--- a/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/examples/midi_host/usb_midi_host_app_driver.c
+++ b/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/examples/midi_host/usb_midi_host_app_driver.c
@@ -1,0 +1,50 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 rppicomidi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+#include "tusb_option.h"
+
+#if (TUSB_OPT_HOST_ENABLED)
+
+#include "host/usbh.h"
+#include "host/usbh_pvt.h"
+
+#include "usb_midi_host.h"
+
+// Install the USB MIDI Host class driver
+usbh_class_driver_t const* usbh_app_driver_get_cb(uint8_t* driver_count)
+{
+  static usbh_class_driver_t host_driver = {
+  #if CFG_TUSB_DEBUG >= 2
+    .name = "MIDIH",
+  #endif
+    .init=midih_init,
+    .deinit=midih_deinit,
+    .open=midih_open,
+    .set_config=midih_set_config,
+    .xfer_cb = midih_xfer_cb,
+    .close = midih_close };
+  *driver_count = 1;
+  return &host_driver;
+}
+#endif

--- a/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/examples/usb_detect/main.cpp
+++ b/Demonstrations+HelloWorlds/PicoSDK/ComputerCard/examples/usb_detect/main.cpp
@@ -1,0 +1,30 @@
+#include "ComputerCard.h"
+
+
+class USBDetect : public ComputerCard
+{
+public:
+
+	virtual void ProcessSample()
+	{
+
+		// Top left LED: downstream facing port (supplying 5V power)
+		LedOn(0, USBPowerState() == DFP);
+
+		// Top right LED: upstream facing port (disconnected, or connected to a device that supplies power)
+		LedOn(1, USBPowerState() == UFP);
+
+		// Bottom right LED: This version of the Computer does not support detection of USB power state
+		LedOn(5, USBPowerState() == Unsupported);
+
+	}
+};
+
+
+int main()
+{
+	USBDetect usbd;
+	usbd.Run();
+}
+
+  


### PR DESCRIPTION
Adding functional USB detection (Rev >=1.1) and a couple of USB MIDI host examples.

There are some small breaking interface changes, to remove `Get` from the start of some ComputerCard methods, and associated renaming of types.