### PR TITLE
Release Od (card #38) Version 1.0

### DIFF
--- a/releases/38_od/README.md
+++ b/releases/38_od/README.md
@@ -1,17 +1,22 @@
 # Od
 
-Od is a program for the Music Thing Modular Workshop System Computer
+Od is a program for the Music Thing Modular Workshop System's Computer
 module that simulates the Lorenz system in order to produce loop-able 
 control voltage and pulse signals that display sensitivity to initial conditions.
 
+To use, download the latest .uf2 file from the 
+[release page](https://github.com/MJLMills/mtmws_od/releases)
+and copy to the Computer module following the 
+[Workshop System instructions](https://www.musicthing.co.uk/Computer_Program_Cards/).
+The latest documentation is available 
+[here](https://github.com/MJLMills/mtmws_od/blob/main/docs/od.pdf).
+
+### Issues and Contact
 This project is developed and documented in
 [a separate repo](https://github.com/MJLMills/mtmws_od), issues and feature 
 requests can be raised there, or by finding the author via the Workshop System 
-Discord (@sneddo_trainer). The majority of the core module code is in the 
+Discord (@sneddo_trainer). The program uses the 
 [pyworkshopsystem](https://github.com/MJLMills/pyworkshopsystem) repo, a
 reusable package for building programs for the Computer module with 
 MicroPython.
 
-A .uf2 file will be provided once features are finalized and tested and all 
-packaging is complete. For now it is possible to try the module out using the 
-provided main.py file (which contains the complete module code).

--- a/releases/38_od/info.yaml
+++ b/releases/38_od/info.yaml
@@ -1,5 +1,5 @@
 Description: Loopable chaotic Lorenz attractor trajectories and zero-crossings as CV and pulses, with sensitivity to initial conditions.
 Language: MicroPython
 Creator:  'M. John Mills'
-Version: 0.0
-Status: Functional but WIP (no .uf2)
+Version: 1.0
+Status: Released


### PR DESCRIPTION
This PR updates the entry for the Od module (#38) in the releases directory, adding a link to the module repo's release page where the (newly available) .uf2 can be downloaded, and a documentary paper.