### PR TITLE
42_backyard_rain: fix README

### DIFF
--- a/releases/42_backyard_rain/README.md
+++ b/releases/42_backyard_rain/README.md
@@ -5,4 +5,4 @@ A port of the [Backyard Rain Soundscape](https://briandorsey.itch.io/backyard-ra
 
 Nature soundscape audio. A cozy rain ambience mix for background listening. You control the intensity. This card plays rain ambience which was recorded in my backyard. 
 
-Crafted Volts is developed in a different GitHub repo, visit [Crafted Volts](https://github.com/briandorsey/mtmws_cards/tree/main/backyard_rain) for documentation and to download releases of the UF2 image. 
+Backyard Rain is developed in a different GitHub repo, visit [Backyard Rain](https://github.com/briandorsey/mtmws_cards/tree/main/backyard_rain) for documentation and to download releases of the UF2 image. 


### PR DESCRIPTION
Download text referred to Crafed Volts instead of Backyard Rain. Oops. :/  (link  was OK).