### PR TITLE
A few more minor bugfixes to Youtube links and font family on the README section

### DIFF
--- a/tools/sitegen/assets/style.css
+++ b/tools/sitegen/assets/style.css
@@ -44,17 +44,6 @@ blockquote{border-left:4px solid var(--border);margin:0;padding:8px 12px;backgro
 .site-footer{border-top:1px solid var(--border);background:color-mix(in srgb, var(--bg), #000 10%);margin-top:40px}
 .site-footer .container{ text-align:center }
 
-/* filter controls */
-.filter-row{display:flex;gap:12px;align-items:center;flex-wrap:wrap}
-.filter-bar label{font-weight:600;color:var(--muted)}
-.filter-bar select{appearance:none;-webkit-appearance:none;-moz-appearance:none;background:var(--card);color:var(--text);border:1px solid var(--border);border-radius:8px;padding:8px 28px 8px 10px;min-width:180px;line-height:1.2}
-.filter-bar select:focus{outline:2px solid var(--accent);outline-offset:1px}
-.theme-dark .filter-bar select{background:#1b222b;color:#fff}
-.theme-light .filter-bar select{background:#fff;color:#0b1220}
-/* try to style the dropdown menu as well (support varies by browser) */
-.theme-dark .filter-bar option{background:#1b222b;color:#fff}
-.theme-light .filter-bar option{background:#fff;color:#0b1220}
-
 /* theme toggle */
 .theme-toggle{appearance:none;-webkit-appearance:none;border:0;background:transparent;cursor:pointer}
 .theme-toggle .track{position:relative;display:inline-flex;align-items:center;gap:6px;width:58px;height:28px;border-radius:999px;background:var(--toggle-track);border:1px solid var(--border);padding:2px}
@@ -103,6 +92,6 @@ blockquote{border-left:4px solid var(--border);margin:0;padding:8px 12px;backgro
 .status-pill.status-archived{background:#e0e0e0}      /* pastel gray */
 .status-pill.status-unknown{background:#dde3ea}       /* default light */
 
-/* responsive video embeds */
+/* video embeds */
 .video-embed{position:relative;padding-bottom:56.25%;height:0;overflow:hidden;border:1px solid var(--border);border-radius:8px;background:color-mix(in srgb, var(--bg), #000 8%);margin:16px 0}
 .video-embed iframe{position:absolute;top:0;left:0;width:100%;height:100%;border:0}

--- a/tools/sitegen/assets/style.css
+++ b/tools/sitegen/assets/style.css
@@ -15,6 +15,7 @@
 .card-num svg{height:42px;width:auto;display:block}
 .card-body{padding:16px;display:flex;flex-direction:column;flex:1}
 .card-body .btn{margin-top:12px}
+.markdown-body{font-family:"Inter",system-ui,Segoe UI,Roboto,Helvetica,Arial,"Apple Color Emoji","Segoe UI Emoji"}
 .actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:12px;justify-content:center}
 /* large card for detail pages */
 .card.large{width:100%;margin:40px 0;font-size:20px}
@@ -23,7 +24,7 @@
 .card.large .card-body{padding:28px}
 .card.large .meta-list li{font-size:18px}
 .card.large .actions .btn{font-size:18px;padding:14px 20px}
-.card.large .markdown-body{font-size:16px}
+.card.large .markdown-body{font-size:16px;font-family:"Inter",system-ui,Segoe UI,Roboto,Helvetica,Arial,"Apple Color Emoji","Segoe UI Emoji"}
 .card.large .markdown-body h1{font-size:28px}
 .card.large .markdown-body h2{font-size:24px}
 .card.large .markdown-body h3{font-size:20px}

--- a/tools/sitegen/assets/style.css
+++ b/tools/sitegen/assets/style.css
@@ -15,7 +15,7 @@
 .card-num svg{height:42px;width:auto;display:block}
 .card-body{padding:16px;display:flex;flex-direction:column;flex:1}
 .card-body .btn{margin-top:12px}
-.markdown-body{font-family:"Inter",system-ui,Segoe UI,Roboto,Helvetica,Arial,"Apple Color Emoji","Segoe UI Emoji"}
+.markdown-body{font-family:"Inter",Segoe UI,Roboto,Helvetica,Arial,"Apple Color Emoji","Segoe UI Emoji"}
 .actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:12px;justify-content:center}
 /* large card for detail pages */
 .card.large{width:100%;margin:40px 0;font-size:20px}

--- a/tools/sitegen/src/render/layout.js
+++ b/tools/sitegen/src/render/layout.js
@@ -7,6 +7,9 @@ export function renderLayout({ title, content, relativeRoot = '.', repoUrl = 'ht
   <title>${title ? String(title).replace(/</g, '&lt;') : 'Workshop Computer'}</title>
   <script>(function(){try{var k='wc-theme';var d=document.documentElement;var prefersDark=window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches;var t=localStorage.getItem(k);if(t!=='dark'&&t!=='light'){t=prefersDark?'dark':'light';}d.classList.remove('theme-dark','theme-light');d.classList.add('theme-'+t);d.setAttribute('data-theme',t);}catch(e){}})();</script>
   <link rel="stylesheet" href="${relativeRoot}/assets/github-markdown.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="${relativeRoot}/assets/style.css" />
   <style>
     .filter-bar{margin:0 0 16px 0}


### PR DESCRIPTION
This pull request updates the site generator's styling and YouTube embed logic to improve visual consistency and user experience. The main changes include standardizing font usage across markdown content, simplifying the YouTube embed injector to preserve link text, and removing unused filter bar CSS. Below are the most important changes, grouped by theme:

**Styling and Fonts**

* Standardized the font family for `.markdown-body` and `.card.large .markdown-body` to use "Inter" and system fonts, ensuring consistent typography for markdown-rendered content. [[1]](diffhunk://#diff-bb7c4de937cb7e2872ee267bb66ddbf0b20afa884a82dffc366db90e6884a854R18) [[2]](diffhunk://#diff-bb7c4de937cb7e2872ee267bb66ddbf0b20afa884a82dffc366db90e6884a854L26-R27)
* Added Google Fonts preconnect and stylesheet links for "Inter" to the HTML layout, enabling proper font loading. (`tools/sitegen/src/render/layout.js`)

**CSS Cleanup**

* Removed all filter bar and filter row CSS rules from `style.css`, cleaning up unused styles related to filtering controls.

**YouTube Embed Handling**

* Replaced the previous complex YouTube embed logic with a minimal injector that appends a YouTube embed after each YouTube link, preserving the original link text. (`tools/sitegen/src/discover/release.js`) [[1]](diffhunk://#diff-7212cdd305209bc4dbc0ed7625605f98d6de482f7f660da57d8cd96fdcc7c394L59-L129) [[2]](diffhunk://#diff-7212cdd305209bc4dbc0ed7625605f98d6de482f7f660da57d8cd96fdcc7c394L146-R76) [[3]](diffhunk://#diff-7212cdd305209bc4dbc0ed7625605f98d6de482f7f660da57d8cd96fdcc7c394R97-R123)
* Updated the comment for video embeds in `style.css` to reflect the change from "responsive video embeds" to "video embeds".