### PR TITLE
CSS fix for Dark Mode header text

### DIFF
--- a/tools/sitegen/assets/style.css
+++ b/tools/sitegen/assets/style.css
@@ -183,6 +183,8 @@ html,body{margin:0;padding:0;background:var(--bg);color:var(--text);font:16px/1.
   ===================================================================== */
 /* Make all links in dark mode readable blue */
 .theme-dark a{color:#4ea1ff}
+/* Keep site title/header link white in dark mode */
+.theme-dark .site-header a{color:#fff !important}
 /* But keep button text white for contrast on button backgrounds */
 .theme-dark .btn{color:#fff !important}
 


### PR DESCRIPTION
Sometimes the AI just does what it wants, and I missed the issue it had introduced. >.<

Ensure site header links remain white in dark mode for improved readability and accessibility.