### PR TITLE
pages.yml - skip jobs in forked repos

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,6 +16,8 @@ concurrency:
 
 jobs:
   build:
+    # Don't run on forked repositories
+    if: github.event.repository.fork != true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -40,6 +42,8 @@ jobs:
           path: site
 
   deploy:
+    # Don't run on forked repositories
+    if: github.event.repository.fork != true
     needs: build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This change attempts to avoid failed workflows running in all forks of Workshop_Computer when changes to the README trigger updates to GitHub pages. 

Example run that failed in my fork (because I don't have GitHub pages enabled):
https://github.com/briandorsey/Workshop_Computer/actions/runs/17899142698

The workflow currently uses a filter to only run on changes pushed to 'main'... but it seems like this triggers when changes to main are synced to forks as well. 

This update adds an additional `if` check in each job, and skips the job when running on a fork. Tested in my repo with a manual workflow run and it seems to work here. I think this should still run properly in the main repo, but I can't test that directly. Pattern learned from this blog post: https://beckysweger.com/2025/01/02/skip-a-job-in-a.html