### PR TITLE
Fix CV outputs not responding to _c.tell commands (fixes norns CV output)

### DIFF
--- a/releases/41_blackbird/main.cpp
+++ b/releases/41_blackbird/main.cpp
@@ -4378,10 +4378,13 @@ int LuaManager::lua_c_tell(lua_State* L) {
                     hardware_pulse_output_set(pulse_idx + 1, state);
                 }
             } else {
-                // Regular CV outputs (channels 1-4)
+                // Regular CV outputs (channels 1-2 are CV, 3-4 are audio)
+                // Must route through LL_set_volts / slope system so that
+                // ProcessSample() sees the updated slope state instead of
+                // overwriting it with the idle (0V) slope value every sample.
                 float value = (float)luaL_checknumber(L, 3);
-                
-                // User explicitly setting output.volts should always disable noise
+
+                // User explicitly setting output should always disable noise
                 int ch_idx = channel - 1;
                 if (ch_idx >= 0 && ch_idx < 4 && g_noise_active[ch_idx]) {
                     g_noise_active[ch_idx] = false;
@@ -4389,8 +4392,17 @@ int LuaManager::lua_c_tell(lua_State* L) {
                     g_noise_gain[ch_idx] = 0;
                     g_noise_lock_counter[ch_idx] = 0;
                 }
-                
-                hardware_output_set_voltage(channel, value);
+
+                // Route through slope system (like LL_set_volts does) so
+                // ProcessSample's slope loop drives the hardware output.
+                // hardware_output_set_voltage() alone gets clobbered by the
+                // slope loop writing the stale idle value every ~104µs.
+                casl_cleardynamics(ch_idx);
+                casl_describe_to_literal_q16(ch_idx,
+                                             FLOAT_TO_Q16(value),
+                                             FLOAT_TO_Q16(0.0f),  // instant slew
+                                             SHAPE_Linear);
+                casl_action(ch_idx, 1);
             }
     } else {
         // Only 'output' is handled here - all other _c.tell messages (stream, change, window, etc)


### PR DESCRIPTION
Be aware that this fix was identified, debugged, implemented and reviewed using an LLM and coding agent (pi). The fix was also manually verified with norns by me.

─────────────────────────────────────────────────────

Bug

When using Blackbird with monome norns, CV outputs 1 & 2 did not respond to voltage commands. Audio (CV/audio) outputs worked correctly, and LEDs indicated signal was present, but no actual CV voltage appeared on the CV out jacks. The same issue affected any host application that routes output commands through _c.tell('output', channel, value).

Root Cause

_c.tell('output', channel, value) in lua_c_tell() called hardware_output_set_voltage() directly, which wrote to the CV output hardware immediately. However, ProcessSample() on Core 1 unconditionally writes all 4 slope channels to hardware every ~104µs. Since the slope for that channel was idle at 0V, it overwrote the direct hardware write within microseconds — effectively erasing it before it could be measured.

The working path (output[n].volts = x → LL_set_volts) already routed through the slope system correctly, which is why direct Lua commands worked but norns (which uses _c.tell internally) did not.

Fix

Changed lua_c_tell() to route through the slope system (casl_cleardynamics + casl_describe_to_literal_q16 + casl_action) instead of calling hardware_output_set_voltage directly. This ensures the slope engine drives the hardware output consistently from ProcessSample().