### PR TITLE
add PICO_BOARD pico to Twists CMakeLists

### DIFF
--- a/releases/10_twists/src/CMakeLists.txt
+++ b/releases/10_twists/src/CMakeLists.txt
@@ -23,7 +23,7 @@ if (EXISTS ${picoVscode})
     include(${picoVscode})
 endif()
 # ====================================================================================
-set(PICO_BOARD "computer")
+set(PICO_BOARD "pico")
 
 # Pull in Raspberry Pi Pico SDK (must be before project)
 include(pico_sdk_import.cmake)


### PR DESCRIPTION
This change is so that when we add an upcoming devcontainer env to Workshop_Computer (including the ability to make all pico sdk cards simultaneously), that we don't need to maintain a separate computer.h file at the root just for Twists.

I've confirmed Twists still builds after this change!

@tomwaters  can I merge this with your blessing?