### PR TITLE
Add devcontainer harness!

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,67 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG PICO_SDK_VERSION
+ARG TINYUSB_VERSION
+
+RUN if [ -z "$PICO_SDK_VERSION" ]; then \
+        echo "PICO_SDK_VERSION is required. Set it in .devcontainer/devcontainer.json under build.args."; \
+        exit 1; \
+    fi
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        git \
+        ca-certificates \
+        cmake \
+        ninja-build \
+        build-essential \
+        gdb-multiarch \
+        python3 \
+        python3-pip \
+        pkg-config \
+        libusb-1.0-0-dev \
+        wget \
+        xz-utils \
+        libncurses5 \
+    && if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
+        apt-get install -y --no-install-recommends libc6-i386; \
+    fi \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install ARM GCC toolchain 14.2.Rel1 to match typical macOS setup
+RUN if [ "$(dpkg --print-architecture)" = "arm64" ]; then \
+        TOOLCHAIN_URL="https://developer.arm.com/-/media/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-aarch64-arm-none-eabi.tar.xz"; \
+    else \
+        TOOLCHAIN_URL="https://developer.arm.com/-/media/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi.tar.xz"; \
+    fi \
+    && wget -q "$TOOLCHAIN_URL" -O /tmp/arm-toolchain.tar.xz \
+    && mkdir -p /opt/arm-toolchain \
+    && tar -xf /tmp/arm-toolchain.tar.xz -C /opt/arm-toolchain --strip-components=1 \
+    && rm /tmp/arm-toolchain.tar.xz
+
+ENV PATH="/opt/arm-toolchain/bin:${PATH}"
+
+RUN git clone --depth 1 --branch ${PICO_SDK_VERSION} https://github.com/raspberrypi/pico-sdk.git /opt/pico-sdk \
+    && git -C /opt/pico-sdk submodule update --init --recursive
+
+# Pin TinyUSB to a known-good tag for Workshop_Computer releases
+RUN if [ -n "$TINYUSB_VERSION" ]; then \
+        git -C /opt/pico-sdk/lib/tinyusb fetch --tags \
+        && git -C /opt/pico-sdk/lib/tinyusb checkout ${TINYUSB_VERSION}; \
+    fi
+
+# Make the SDK path available during the picotool build.
+ENV PICO_SDK_PATH=/opt/pico-sdk
+
+# Note: the MAKEFILES auto-include (scripts/pico_auto_make.mk) is set via
+# devcontainer.json's remoteEnv using ${containerWorkspaceFolder}, so the path
+# adapts to the workspace folder name instead of being baked into the image.
+
+# Install picotool so the Pico SDK build doesn't need to fetch it.
+# Match the SDK version by default.
+RUN git clone --depth 1 --branch ${PICO_SDK_VERSION} https://github.com/raspberrypi/picotool.git /tmp/picotool \
+    && cmake -S /tmp/picotool -B /tmp/picotool/build -G Ninja -DCMAKE_BUILD_TYPE=Release \
+    && cmake --build /tmp/picotool/build \
+    && cmake --install /tmp/picotool/build \
+    && rm -rf /tmp/picotool

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,81 @@
+# Dev container build harness
+
+This folder plus the top-level `Makefile` and the helpers under `scripts/`
+(including the `start_openocd_host.*` wrappers) provide a reproducible way to
+build (and optionally flash/debug) the Pico SDK firmware in this repo from
+inside a VS Code Dev Container.
+
+Nothing here changes how cards are structured: a card under `releases/<card>/`
+only needs its `CMakeLists.txt` and `pico_sdk_import.cmake`. The harness supplies
+the toolchain and `make` behavior.
+
+## Quick start
+
+1. Install Docker and the VS Code **Dev Containers** extension.
+2. Open this repo in VS Code and **Reopen in Container**.
+3. Build a card:
+
+   ```sh
+   cd releases/10_twists/src
+   make            # configure + build into ./build/
+   make uf2        # stage produced *.uf2 into ./UF2/
+   ```
+
+The container ships CMake, Ninja, the ARM GCC toolchain, a pinned Pico SDK at
+`/opt/pico-sdk`, and picotool. The Pico SDK / TinyUSB versions are selected at
+build time in [devcontainer.json](devcontainer.json) under `build.args`.
+
+## How `make` works without a per-card Makefile
+
+The container sets `MAKEFILES` to auto-include
+[`scripts/pico_auto_make.mk`](../scripts/pico_auto_make.mk). In any directory
+that looks like a Pico SDK CMake project but has no local `Makefile`, this
+provides:
+
+- `make` / `make build` — configure + build into `./build/`
+- `make uf2` — stage produced `*.uf2` into `./UF2/`
+- `make clean` — remove the build directory
+- `make flash` — flash via GDB against a host-side OpenOCD (see below)
+
+From the repo root you can also build any project directory with
+`make <dir>` (delegates to [`scripts/build.sh`](../scripts/build.sh)), or build
+every compatible `releases/*` card with `make all`.
+
+## Pico SDK resolution order
+
+1. `PICO_SDK_PATH` if already set
+2. `/opt/pico-sdk` (the container default)
+3. Otherwise Pico SDK FetchContent (`PICO_SDK_FETCH_FROM_GIT*` variables)
+
+## Flashing / debugging (host-side OpenOCD)
+
+Flashing runs OpenOCD **on the host** and connects from inside the container to
+its GDB server at `host.docker.internal:3333`. This keeps USB probe access and
+permissions simple across platforms.
+
+Start OpenOCD on the host:
+
+- macOS/Linux: `./scripts/start_openocd_host.sh`
+- Windows: `powershell -ExecutionPolicy Bypass -File .\scripts\start_openocd_host.ps1`
+
+Then, inside the container:
+
+```sh
+cd releases/10_twists/src
+make flash
+```
+
+`make flash` selects the target from the newest `UF2/*.uf2` (or `FLASH_UF2=...`)
+and flashes the matching `build/<stem>.elf`. Useful variables:
+`OPENOCD_HOST`, `OPENOCD_GDB_PORT`, `FLASH_UF2`, `FLASH_ELF`, `GDB`.
+
+Debug probe reference: https://learn.adafruit.com/raspberry-pi-pico-debug-probe
+
+## Notes
+
+- VS Code tasks/launch configs are intentionally not committed (this repo
+  ignores `.vscode/`); wire up your own if you want F5 debugging against the
+  running OpenOCD GDB server.
+- Submodules (e.g. `releases/41_blackbird/lua`) are not initialized
+  automatically; run `git submodule update --init --recursive <path>` only for
+  the card you are building.

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -71,11 +71,26 @@ and flashes the matching `build/<stem>.elf`. Useful variables:
 
 Debug probe reference: https://learn.adafruit.com/raspberry-pi-pico-debug-probe
 
+## VS Code tasks and F5 debugging
+
+The committed `.vscode/` configs let you build, flash, and debug without the
+terminal. They ask for the **card directory** via a prompt (default
+`releases/04_BYO_Benjolin`) instead of guessing from the open file, so they work
+no matter what you have focused:
+
+- **Tasks** (`Run Task`): `ComputerCard: build`, `ComputerCard: flash`.
+- **Debug (F5)**: `ComputerCard: attach (OpenOCD)` builds the card, attaches
+  Cortex-Debug to the host OpenOCD GDB server, and breaks at `main`. Start
+  OpenOCD on the host first (see above).
+
+The debug config loads `<cardDir>/build/.last.elf` — a symlink the build step
+updates to the most recently built ELF — so it is card-name agnostic.
+
+Only `tasks.json`, `launch.json`, and `extensions.json` are tracked; personal
+VS Code settings under `.vscode/` remain ignored.
+
 ## Notes
 
-- VS Code tasks/launch configs are intentionally not committed (this repo
-  ignores `.vscode/`); wire up your own if you want F5 debugging against the
-  running OpenOCD GDB server.
 - Submodules (e.g. `releases/41_blackbird/lua`) are not initialized
   automatically; run `git submodule update --init --recursive <path>` only for
   the card you are building.

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -16,9 +16,8 @@ the toolchain and `make` behavior.
 3. Build a card:
 
    ```sh
-   cd releases/10_twists/src
-   make            # configure + build into ./build/
-   make uf2        # stage produced *.uf2 into ./UF2/
+   cd releases/11_goldfish
+   make            # configure + build into ./build/, and stage *.uf2 into ./UF2/
    ```
 
 The container ships CMake, Ninja, the ARM GCC toolchain, a pinned Pico SDK at
@@ -32,8 +31,10 @@ The container sets `MAKEFILES` to auto-include
 that looks like a Pico SDK CMake project but has no local `Makefile`, this
 provides:
 
-- `make` / `make build` — configure + build into `./build/`
-- `make uf2` — stage produced `*.uf2` into `./UF2/`
+- `make` / `make build` — configure + build into `./build/`, and stage any
+  produced `*.uf2` into `./UF2/`
+- `make uf2` — same as `make build`, then print the staged `*.uf2` path(s)
+  (staging already happens during the build; this is just for convenience)
 - `make clean` — remove the build directory
 - `make flash` — flash via GDB against a host-side OpenOCD (see below)
 
@@ -49,7 +50,7 @@ every compatible `releases/*` card with `make all`.
 
 ## Flashing / debugging (host-side OpenOCD)
 
-Flashing runs OpenOCD **on the host** and connects from inside the container to
+Flashing runs OpenOCD **on the host (outside the container!)** and connects from inside the container to
 its GDB server at `host.docker.internal:3333`. This keeps USB probe access and
 permissions simple across platforms.
 
@@ -61,7 +62,7 @@ Start OpenOCD on the host:
 Then, inside the container:
 
 ```sh
-cd releases/10_twists/src
+cd releases/11_goldfish
 make flash
 ```
 
@@ -74,23 +75,69 @@ Debug probe reference: https://learn.adafruit.com/raspberry-pi-pico-debug-probe
 ## VS Code tasks and F5 debugging
 
 The committed `.vscode/` configs let you build, flash, and debug without the
-terminal. They ask for the **card directory** via a prompt (default
-`releases/04_BYO_Benjolin`) instead of guessing from the open file, so they work
-no matter what you have focused:
+terminal. Instead of guessing the card from the open file, they ask **once** for
+the card folder and remember it.
 
-- **Tasks** (`Run Task`): `ComputerCard: build`, `ComputerCard: flash`.
-- **Debug (F5)**: `ComputerCard: attach (OpenOCD)` builds the card, attaches
-  Cortex-Debug to the host OpenOCD GDB server, and breaks at `main`. Start
-  OpenOCD on the host first (see above).
+### Choosing the card
 
-The debug config loads `<cardDir>/build/.last.elf` — a symlink the build step
-updates to the most recently built ELF — so it is card-name agnostic.
+The first time you build/flash/debug, a native **folder picker** opens (starting
+in `releases/`). Pick a card folder and the choice is remembered under the key
+`cardDir` and reused for every later build/flash/debug — no more prompts.
 
-Only `tasks.json`, `launch.json`, and `extensions.json` are tracked; personal
-VS Code settings under `.vscode/` remain ignored.
+- The choice is persisted to `.vscode/.card.json` (git-ignored) so it survives
+  window reloads and container restarts.
+- To switch cards, run the **`ComputerCard: select card`** task; it reopens the
+  folder picker and overwrites the stored choice (takes effect immediately, no
+  reload needed).
 
-## Notes
+This is powered by the `rioj7.command-variable` extension (installed
+automatically in the container). Both `tasks.json` and `launch.json` share the
+same `cardDir` key, so pressing play prompts at most once — the `preLaunchTask`
+reuses the remembered value.
 
-- Submodules (e.g. `releases/41_blackbird/lua`) are not initialized
-  automatically; run `git submodule update --init --recursive <path>` only for
-  the card you are building.
+### Tasks (`Run Task`)
+
+- `ComputerCard: build` — `make build`, then refresh the `build/.last.elf`
+  symlink (see below).
+- `ComputerCard: flash` — `make flash` (programs the chip via host OpenOCD).
+- `ComputerCard: build + flash` — build then flash; used as the debug
+  pre-launch step.
+- `ComputerCard: select card` — change the remembered card folder.
+
+### Debug (F5)
+
+`ComputerCard: attach (OpenOCD)`:
+
+1. Runs `ComputerCard: build + flash`, so the **selected card is programmed onto
+   the chip** first.
+2. Attaches Cortex-Debug to the host OpenOCD GDB server and breaks at `main`.
+
+Start OpenOCD on the host first (see the section above). The config loads
+`<cardDir>/build/.last.elf` — a symlink that the build step
+([`scripts/last_elf.sh`](../scripts/last_elf.sh)) points at the most recently
+built ELF. That script runs after every build so the symlink exists even for
+cards that ship their own `Makefile`/`GNUmakefile` (which the Pico auto-make
+harness does not create), keeping the debug config card-name agnostic.
+
+### Live Watch
+
+The debug config enables Cortex-Debug **Live Watch** (`liveWatch.enabled`,
+sampling a few times per second). To use it:
+
+- During a session, open the **LIVE WATCH** tree in the Run and Debug sidebar
+  and click **+** to add expressions (it starts empty).
+- Values update only while the target is **running** — press **Continue** after
+  the initial break at `main`.
+- Only globals/statics can be live-watched (Live Watch reads memory by fixed
+  address while the CPU runs; stack locals have no fixed address).
+
+### Required extensions
+
+Installed automatically in the container (and recommended in
+`.vscode/extensions.json`): `marus25.cortex-debug`,
+`mcu-debug.debug-tracker-vscode` (a Cortex-Debug dependency),
+`ms-vscode.cpptools`, and `rioj7.command-variable`.
+
+`tasks.json`, `launch.json`, `extensions.json`, and `settings.json` are tracked;
+the remembered-card file `.vscode/.card.json` and other personal `.vscode/`
+files remain ignored.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,6 +17,7 @@
     "vscode": {
       "extensions": [
         "marus25.cortex-debug",
+        "mcu-debug.debug-tracker-vscode",
         "ms-vscode.cpptools",
         "rioj7.command-variable"
       ],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,8 +17,8 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "marus25.cortex-debug",
         "mcu-debug.debug-tracker-vscode",
+        "marus25.cortex-debug",
         "ms-vscode.cpptools",
         "rioj7.command-variable"
       ],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,6 +13,7 @@
     "PICO_SDK_PATH": "/opt/pico-sdk",
     "MAKEFILES": "${containerWorkspaceFolder}/scripts/pico_auto_make.mk"
   },
+  "postCreateCommand": "git submodule update --init --recursive",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+{
+  "name": "ComputerCard",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      "PICO_SDK_VERSION": "2.2.0",
+      "TINYUSB_VERSION": "0.20.0"
+    }
+  },
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "runArgs": ["--add-host=host.docker.internal:host-gateway"],
+  "remoteEnv": {
+    "PICO_SDK_PATH": "/opt/pico-sdk",
+    "MAKEFILES": "${containerWorkspaceFolder}/scripts/pico_auto_make.mk"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "marus25.cortex-debug",
+        "ms-vscode.cpptools"
+      ],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash"
+      }
+    }
+  }
+}
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
     "PICO_SDK_PATH": "/opt/pico-sdk",
     "MAKEFILES": "${containerWorkspaceFolder}/scripts/pico_auto_make.mk"
   },
-  "postCreateCommand": "git submodule update --init --recursive",
+  "postCreateCommand": "git config -f .gitmodules --get-regexp path | awk '{ print $2 }' | xargs -r git submodule update --init --recursive --",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,7 +20,8 @@
         "ms-vscode.cpptools"
       ],
       "settings": {
-        "terminal.integrated.defaultProfile.linux": "bash"
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "cmake.ignoreCMakeListsMissing": true
       }
     }
   }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,11 +17,13 @@
     "vscode": {
       "extensions": [
         "marus25.cortex-debug",
-        "ms-vscode.cpptools"
+        "ms-vscode.cpptools",
+        "rioj7.command-variable"
       ],
       "settings": {
         "terminal.integrated.defaultProfile.linux": "bash",
-        "cmake.ignoreCMakeListsMissing": true
+        "cmake.ignoreCMakeListsMissing": true,
+        "commandvariable.remember.persistent.file": "${workspaceFolder}${pathSeparator}.vscode${pathSeparator}.card.json"
       }
     }
   }

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ Icon?
 .vscode/
 site/
 tools/sitegen/node_modules/
+
+# Build harness output (per-card CMake build dirs)
+**/build/

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,10 @@ Icon?
 *.tmp
 *.dmp
 .fseventsd
-.vscode/
+.vscode/*
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
 site/
 tools/sitegen/node_modules/
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ Icon?
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+!.vscode/settings.json
 site/
 tools/sitegen/node_modules/
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+  "recommendations": [
+    "marus25.cortex-debug",
+    "ms-vscode.cpptools"
+  ],
+  "unwantedRecommendations": [
+    "ms-vscode.makefile-tools",
+    "ms-vscode.cmake-tools"
+  ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,11 +1,16 @@
 {
   "recommendations": [
     "marus25.cortex-debug",
+    "mcu-debug.debug-tracker-vscode",
     "ms-vscode.cpptools",
     "rioj7.command-variable"
   ],
   "unwantedRecommendations": [
     "ms-vscode.makefile-tools",
-    "ms-vscode.cmake-tools"
+    "ms-vscode.cmake-tools",
+    "ms-vscode-remote.remote-containers",
+    "ms-azuretools.vscode-docker",
+    "ms-vscode.cpptools-extension-pack",
+    "twxs.cmake"
   ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,10 +1,4 @@
 {
-  "recommendations": [
-    "marus25.cortex-debug",
-    "mcu-debug.debug-tracker-vscode",
-    "ms-vscode.cpptools",
-    "rioj7.command-variable"
-  ],
   "unwantedRecommendations": [
     "ms-vscode.makefile-tools",
     "ms-vscode.cmake-tools",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,8 @@
 {
   "recommendations": [
     "marus25.cortex-debug",
-    "ms-vscode.cpptools"
+    "ms-vscode.cpptools",
+    "rioj7.command-variable"
   ],
   "unwantedRecommendations": [
     "ms-vscode.makefile-tools",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+  "version": "0.2.0",
+  "inputs": [
+    {
+      "id": "cardDir",
+      "type": "promptString",
+      "description": "Card directory to build/flash/debug (relative to the repo root, e.g. releases/04_BYO_Benjolin)",
+      "default": "releases/04_BYO_Benjolin"
+    }
+  ],
+  "configurations": [
+    {
+      "name": "ComputerCard: attach (OpenOCD)",
+      "type": "cortex-debug",
+      "request": "attach",
+      "cwd": "${workspaceFolder}/${input:cardDir}",
+      "servertype": "external",
+      "gdbTarget": "host.docker.internal:3333",
+      "gdbPath": "gdb-multiarch",
+      "executable": "${workspaceFolder}/${input:cardDir}/build/.last.elf",
+      "preLaunchTask": "ComputerCard: build",
+      "runToEntryPoint": "main",
+      "postAttachCommands": ["monitor reset init"]
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,10 +2,37 @@
   "version": "0.2.0",
   "inputs": [
     {
+      // Pick-once-and-remember the card folder.
+      //
+      // Uses the "rioj7.command-variable" extension. The first time you
+      // build/flash/debug, a native folder picker opens (starting in
+      // releases/); after that the choice is remembered under the key
+      // "cardDir" (persisted via the "commandvariable.remember.persistent.file"
+      // setting) and reused with no prompt.
+      //
+      // Both launch.json and tasks.json use this same key, so clicking play
+      // resolves the launch config first (which prompts), and the preLaunchTask
+      // reuses the remembered value instead of prompting again.
+      //
+      // To switch cards, run the "ComputerCard: select card" task.
       "id": "cardDir",
-      "type": "promptString",
-      "description": "Card directory to build/flash/debug (relative to the repo root, e.g. releases/04_BYO_Benjolin)",
-      "default": "releases/04_BYO_Benjolin"
+      "type": "command",
+      "command": "extension.commandvariable.remember",
+      "args": {
+        "key": "cardDir",
+        "default": "${openDialog:cardPick}",
+        "transform": {
+          "openDialog": {
+            "cardPick": {
+              "canSelect": "folders",
+              "defaultUri": "${workspaceFolder}/releases",
+              "openLabel": "Use this card",
+              "title": "Select the ComputerCard folder to build / flash / debug",
+              "keyRemember": "cardDir"
+            }
+          }
+        }
+      }
     }
   ],
   "configurations": [
@@ -13,12 +40,12 @@
       "name": "ComputerCard: attach (OpenOCD)",
       "type": "cortex-debug",
       "request": "attach",
-      "cwd": "${workspaceFolder}/${input:cardDir}",
+      "cwd": "${input:cardDir}",
       "servertype": "external",
       "gdbTarget": "host.docker.internal:3333",
       "gdbPath": "gdb-multiarch",
-      "executable": "${workspaceFolder}/${input:cardDir}/build/.last.elf",
-      "preLaunchTask": "ComputerCard: build",
+      "executable": "${input:cardDir}/build/.last.elf",
+      "preLaunchTask": "ComputerCard: build + flash",
       "runToEntryPoint": "main",
       "postAttachCommands": ["monitor reset init"]
     }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -47,7 +47,11 @@
       "executable": "${input:cardDir}/build/.last.elf",
       "preLaunchTask": "ComputerCard: build + flash",
       "runToEntryPoint": "main",
-      "postAttachCommands": ["monitor reset init"]
+      "postAttachCommands": ["monitor reset init"],
+      "liveWatch": {
+        "enabled": true,
+        "samplesPerSecond": 4
+      }
     }
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  // Persist the "remembered" card choice (from the command-variable extension)
+  // across VS Code restarts, so you are only prompted the first time.
+  "commandvariable.remember.persistent.file": "${workspaceFolder}${pathSeparator}.vscode${pathSeparator}.card.json"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,12 @@
 {
   // Persist the "remembered" card choice (from the command-variable extension)
   // across VS Code restarts, so you are only prompted the first time.
-  "commandvariable.remember.persistent.file": "${workspaceFolder}${pathSeparator}.vscode${pathSeparator}.card.json"
+  "commandvariable.remember.persistent.file": "${workspaceFolder}${pathSeparator}.vscode${pathSeparator}.card.json",
+
+  // Stop the CMake Tools extension from scanning the workspace and prompting
+  // you to pick a CMakeLists.txt every time the folder is opened. Building is
+  // driven by the ComputerCard tasks (make), not by CMake Tools.
+  "cmake.configureOnOpen": false,
+  "cmake.configureOnEdit": false,
+  "cmake.automaticReconfigure": false
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,30 @@
+{
+  "version": "2.0.0",
+  "inputs": [
+    {
+      "id": "cardDir",
+      "type": "promptString",
+      "description": "Card directory to build/flash/debug (relative to the repo root, e.g. releases/04_BYO_Benjolin)",
+      "default": "releases/04_BYO_Benjolin"
+    }
+  ],
+  "tasks": [
+    {
+      "label": "ComputerCard: build",
+      "type": "shell",
+      "command": "make",
+      "args": ["build"],
+      "options": { "cwd": "${workspaceFolder}/${input:cardDir}" },
+      "problemMatcher": ["$gcc"],
+      "group": { "kind": "build", "isDefault": true }
+    },
+    {
+      "label": "ComputerCard: flash",
+      "type": "shell",
+      "command": "make",
+      "args": ["flash"],
+      "options": { "cwd": "${workspaceFolder}/${input:cardDir}" },
+      "problemMatcher": []
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,19 +2,49 @@
   "version": "2.0.0",
   "inputs": [
     {
+      // Pick-once-and-remember the card folder. See launch.json for details.
+      // Reuses the value remembered under "cardDir" and only opens the folder
+      // picker if nothing has been chosen yet.
       "id": "cardDir",
-      "type": "promptString",
-      "description": "Card directory to build/flash/debug (relative to the repo root, e.g. releases/04_BYO_Benjolin)",
-      "default": "releases/04_BYO_Benjolin"
+      "type": "command",
+      "command": "extension.commandvariable.remember",
+      "args": {
+        "key": "cardDir",
+        "default": "${openDialog:cardPick}",
+        "transform": {
+          "openDialog": {
+            "cardPick": {
+              "canSelect": "folders",
+              "defaultUri": "${workspaceFolder}/releases",
+              "openLabel": "Use this card",
+              "title": "Select the ComputerCard folder to build / flash / debug",
+              "keyRemember": "cardDir"
+            }
+          }
+        }
+      }
+    },
+    {
+      // Always open the folder picker and (re)store the choice. Used by the
+      // "ComputerCard: select card" task to switch the active card.
+      "id": "cardDirPick",
+      "type": "command",
+      "command": "extension.commandvariable.file.openDialog",
+      "args": {
+        "canSelect": "folders",
+        "defaultUri": "${workspaceFolder}/releases",
+        "openLabel": "Use this card",
+        "title": "Select the ComputerCard folder",
+        "keyRemember": "cardDir"
+      }
     }
   ],
   "tasks": [
     {
       "label": "ComputerCard: build",
       "type": "shell",
-      "command": "make",
-      "args": ["build"],
-      "options": { "cwd": "${workspaceFolder}/${input:cardDir}" },
+      "command": "make build && \"${workspaceFolder}/scripts/last_elf.sh\"",
+      "options": { "cwd": "${input:cardDir}" },
       "problemMatcher": ["$gcc"],
       "group": { "kind": "build", "isDefault": true }
     },
@@ -23,8 +53,23 @@
       "type": "shell",
       "command": "make",
       "args": ["flash"],
-      "options": { "cwd": "${workspaceFolder}/${input:cardDir}" },
+      "options": { "cwd": "${input:cardDir}" },
       "problemMatcher": []
+    },
+    {
+      "label": "ComputerCard: build + flash",
+      "dependsOrder": "sequence",
+      "dependsOn": ["ComputerCard: build", "ComputerCard: flash"],
+      "problemMatcher": [],
+      "detail": "Build the selected card, program it onto the chip, then it's ready to debug."
+    },
+    {
+      "label": "ComputerCard: select card",
+      "type": "shell",
+      "command": "echo",
+      "args": ["Selected card: ${input:cardDirPick}"],
+      "problemMatcher": [],
+      "detail": "Open a folder picker to choose which card the build/flash/debug commands target."
     }
   ]
 }

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ all:
 			failures=$$((failures+1)); \
 		fi; \
 		rm -f "$$log_file"; \
-	done < <(find "$(RELEASES_DIR)" -mindepth 2 -maxdepth 4 -type f -name CMakeLists.txt ! -path "*/lua/*" -print0 | sort -z); \
+	done < <(find "$(RELEASES_DIR)" -mindepth 2 -maxdepth 4 -type f -name CMakeLists.txt ! -path "*/lua/*" ! -path "*/pico-sdk/*" ! -path "*/ComputerCard/*" -print0 | sort -z); \
 	if [[ $$found -eq 0 ]]; then \
 		echo "No CMakeLists.txt found under $(RELEASES_DIR)" >&2; \
 		exit 2; \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,94 @@
+SHELL := /usr/bin/env bash
+
+.PHONY: help all clean FORCE
+
+# Directory to clean when running `make clean` (must be provided explicitly).
+DIR ?=
+
+help:
+	@echo "Usage: make <directory-with-CMakeLists.txt>"
+	@echo "Example: make releases/10_twists/src"
+	@echo ""
+	@echo "Build all compatible releases:"
+	@echo "  make all                  # build every releases/* card with a CMakeLists.txt"
+	@echo ""
+	@echo "Cleaning:"
+	@echo "  make clean DIR=<dir>      # remove <dir>/build"
+	@echo ""
+	@echo "Per-card builds also work from inside a card directory via the"
+	@echo "auto-included scripts/pico_auto_make.mk (make / make uf2 / make flash)."
+
+# Build all compatible Pico SDK releases (sequentially, stop on first failure)
+RELEASES_DIR ?= releases
+
+all:
+	@set -euo pipefail; \
+	if [[ ! -d "$(RELEASES_DIR)" ]]; then \
+		echo "Error: releases directory not found: $(RELEASES_DIR)" >&2; \
+		exit 2; \
+	fi; \
+	found=0; \
+	failures=0; \
+	declare -a targets=(); \
+	declare -a statuses=(); \
+	while IFS= read -r -d '' cmake; do \
+		found=1; \
+		dir=$$(dirname "$$cmake"); \
+		targets+=("$$dir"); \
+		echo "==> Building $$dir"; \
+		log_file=$$(mktemp); \
+		if (cd "$$dir" && make build) 2>&1 | tee "$$log_file"; then \
+			statuses+=("✅ Success"); \
+		else \
+			tinyusb_hit=$$(grep -Eqi "tinyusb|\\btusb\\b" "$$log_file" && echo yes || echo no); \
+			picosdk_hit=$$(grep -Eqi "pico[- ]sdk|PICO_SDK" "$$log_file" && echo yes || echo no); \
+			if [[ "$$tinyusb_hit" == "yes" && "$$picosdk_hit" == "yes" ]]; then \
+				statuses+=("❌ Failed (TinyUSB/Pico SDK issues)"); \
+			elif [[ "$$tinyusb_hit" == "yes" ]]; then \
+				statuses+=("❌ Failed (TinyUSB version mismatch)"); \
+			elif [[ "$$picosdk_hit" == "yes" ]]; then \
+				statuses+=("❌ Failed (Pico SDK version mismatch)"); \
+			else \
+				statuses+=("❌ Failed (Compile errors)"); \
+			fi; \
+			failures=$$((failures+1)); \
+		fi; \
+		rm -f "$$log_file"; \
+	done < <(find "$(RELEASES_DIR)" -mindepth 2 -maxdepth 4 -type f -name CMakeLists.txt ! -path "*/lua/*" -print0 | sort -z); \
+	if [[ $$found -eq 0 ]]; then \
+		echo "No CMakeLists.txt found under $(RELEASES_DIR)" >&2; \
+		exit 2; \
+	fi; \
+	total=$${#targets[@]}; \
+	successes=$$((total - failures)); \
+	echo ""; \
+	echo "| Target path | Build status |"; \
+	echo "| --- | --- |"; \
+	while IFS=$$'\t' read -r target status; do \
+		echo "| $$target | $$status |"; \
+	done < <(for i in "$${!targets[@]}"; do printf '%s\t%s\n' "$${targets[$$i]}" "$${statuses[$$i]}"; done | sort); \
+	echo ""; \
+	echo "Total: $$total, Success: $$successes, Failed: $$failures"; \
+	if [[ $$failures -gt 0 ]]; then \
+		exit 2; \
+	fi
+
+clean:
+	@if [[ -z "$(DIR)" ]]; then \
+		echo "Error: DIR not set (usage: make clean DIR=<dir>)" >&2; \
+		exit 2; \
+	fi
+	@if [[ ! -d "$(DIR)" ]]; then \
+		echo "Error: directory not found: $(DIR)" >&2; \
+		exit 2; \
+	fi
+	@rm -rf "$(DIR)/build"
+
+# Build an arbitrary directory that contains a CMakeLists.txt.
+%: FORCE
+	@./scripts/build.sh "$@"
+
+FORCE:
+
+Makefile:
+	@:

--- a/README.md
+++ b/README.md
@@ -14,11 +14,20 @@ Further discussion in the Discord - invite in the documentation below.
 At the moment, [this Google doc is the most up-to-date shortform documentation](https://docs.google.com/document/d/1NsRewxAu9X8dQMUTdN0eeJeRCr0HmU0pUjpKB4gM-xo/edit?usp=sharing) for pinouts and hardware details
 
 
+### BUILDING, FLASHING & DEBUGGING
+
+
+
 ### Demonstrations+HelloWorlds
 
 Starter code in various platforms - Arduino, Pico SDK, CircuitPython, Micropython
 
-By far the most developed is [Chris Johnson's ComputerCard library](https://github.com/TomWhitwell/Workshop_Computer/tree/main/Demonstrations%2BHelloWorlds/PicoSDK/ComputerCard) for SDK and Arduino: 
+By far the most developed is [Chris Johnson's ComputerCard library](https://github.com/TomWhitwell/Workshop_Computer/tree/main/Demonstrations%2BHelloWorlds/PicoSDK/ComputerCard) for Pico SDK and Arduino.
+
+The easiest way to get started building, flashing, and debugging ComputerCard firmware
+is the **Visual Studio Code DevContainer**, that automatically installs everything you need into a tiny linux environment on your (non-workshop) computer and makes building, flashing, and debugging much easier. See
+[.devcontainer/README.md](.devcontainer/README.md) to get going.
+
 
 ### RELEASES 
 

--- a/releases/15_MLRws/GNUmakefile
+++ b/releases/15_MLRws/GNUmakefile
@@ -18,9 +18,12 @@ OPENOCD_HOST     ?= host.docker.internal
 OPENOCD_GDB_PORT ?= 3333
 GDB ?= $(shell command -v arm-none-eabi-gdb 2>/dev/null || command -v gdb-multiarch 2>/dev/null)
 
-.PHONY: all firmware monobright flash flash-monobright clean help
+.PHONY: all build firmware monobright flash flash-monobright clean help
 
 all: firmware
+
+# Alias so the root `make all` (which invokes `make build` per card) works here.
+build: firmware
 
 firmware:
 	@mkdir -p $(BUILD)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  build.sh <directory-with-CMakeLists.txt> [options]
+
+Options:
+  --target <cmake-target>   Build a single CMake target
+  --configure-only          Configure only; do not build
+  --clean                   Remove the build directory and exit
+
+Environment:
+  PICO_SDK_PATH             Pico SDK location (optional)
+  COMPUTERCARD_DEPS_DIR     Shared dependency cache root (default: ~/.cache/computercard)
+  COMPUTERCARD_BUILD_DIR    Build directory override (default: <dir>/build)
+  COMPUTERCARD_GENERATOR    CMake generator (default: Ninja)
+EOF
+}
+
+if [[ $# -lt 1 ]]; then
+  usage
+  exit 1
+fi
+
+TARGET_DIR="$1"; shift
+
+TARGET=""
+CONFIGURE_ONLY=0
+CLEAN=0
+
+GENERATOR="${COMPUTERCARD_GENERATOR:-Ninja}"
+DEPS_DIR="${COMPUTERCARD_DEPS_DIR:-${HOME}/.cache/computercard}"
+BUILD_DIR="${COMPUTERCARD_BUILD_DIR:-$TARGET_DIR/build}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target)
+      if [[ $# -lt 2 ]]; then
+        echo "Error: --target requires a value" >&2
+        usage
+        exit 2
+      fi
+      TARGET="$2"
+      shift 2
+      ;;
+    --configure-only)
+      CONFIGURE_ONLY=1
+      shift
+      ;;
+    --clean)
+      CLEAN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Error: unknown option: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! -d "$TARGET_DIR" ]]; then
+  echo "Error: directory not found: $TARGET_DIR" >&2
+  exit 1
+fi
+
+if [[ ! -f "$TARGET_DIR/CMakeLists.txt" ]]; then
+  echo "Error: expected a directory containing CMakeLists.txt: $TARGET_DIR" >&2
+  exit 1
+fi
+
+if [[ $CLEAN -eq 1 ]]; then
+  rm -rf "$BUILD_DIR"
+  exit 0
+fi
+
+# Always clean before (re)configure/build for reproducible builds.
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR"
+
+# Cache directory for CMake FetchContent downloads (shared across builds).
+mkdir -p "$DEPS_DIR/fetchcontent"
+
+if [[ -f "$BUILD_DIR/CMakeCache.txt" ]]; then
+  EXISTING_GENERATOR="$(grep -E '^CMAKE_GENERATOR:INTERNAL=' "$BUILD_DIR/CMakeCache.txt" | cut -d= -f2- || true)"
+  if [[ -n "$EXISTING_GENERATOR" && "$EXISTING_GENERATOR" != "$GENERATOR" ]]; then
+    echo "Build dir generator mismatch ($EXISTING_GENERATOR vs $GENERATOR); recreating $BUILD_DIR" >&2
+    rm -rf "$BUILD_DIR"
+    mkdir -p "$BUILD_DIR"
+  fi
+fi
+
+CMAKE_ARGS=("-S" "$TARGET_DIR" "-B" "$BUILD_DIR" "-G" "$GENERATOR")
+if [[ -n "${PICO_SDK_PATH:-}" ]]; then
+  CMAKE_ARGS+=("-DPICO_SDK_PATH=${PICO_SDK_PATH}")
+fi
+
+if [[ -n "${PICO_TOOLCHAIN_PATH:-}" ]]; then
+  CMAKE_ARGS+=("-DPICO_TOOLCHAIN_PATH=${PICO_TOOLCHAIN_PATH}")
+else
+  TOOLCHAIN_BIN="$(command -v arm-none-eabi-gcc || true)"
+  if [[ -n "$TOOLCHAIN_BIN" ]]; then
+    TOOLCHAIN_ROOT="$(cd "$(dirname "$TOOLCHAIN_BIN")/.." && pwd)"
+    CMAKE_ARGS+=("-DPICO_TOOLCHAIN_PATH=${TOOLCHAIN_ROOT}")
+  fi
+fi
+
+TOOLCHAIN_C="$(command -v arm-none-eabi-gcc || true)"
+TOOLCHAIN_CXX="$(command -v arm-none-eabi-g++ || true)"
+if [[ -n "$TOOLCHAIN_C" ]]; then
+  CMAKE_ARGS+=("-DCMAKE_C_COMPILER=${TOOLCHAIN_C}")
+fi
+if [[ -n "$TOOLCHAIN_CXX" ]]; then
+  CMAKE_ARGS+=("-DCMAKE_CXX_COMPILER=${TOOLCHAIN_CXX}")
+fi
+
+# Reuse downloaded dependencies across builds.
+CMAKE_ARGS+=("-DFETCHCONTENT_BASE_DIR=${DEPS_DIR}/fetchcontent")
+CMAKE_ARGS+=("-DFETCHCONTENT_UPDATES_DISCONNECTED=ON")
+
+cmake "${CMAKE_ARGS[@]}"
+
+if [[ $CONFIGURE_ONLY -eq 1 ]]; then
+  exit 0
+fi
+
+if [[ -n "$TARGET" ]]; then
+  cmake --build "$BUILD_DIR" --target "$TARGET"
+else
+  cmake --build "$BUILD_DIR"
+fi

--- a/scripts/last_elf.sh
+++ b/scripts/last_elf.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Create/refresh a stable "build/.last.elf" symlink pointing at the most
+# recently built firmware ELF.
+#
+# The VS Code debug configuration (.vscode/launch.json) attaches to
+# "<card>/build/.last.elf". Not every build path creates that symlink:
+# pico_auto_make.mk does, but cards with their own Makefile/GNUmakefile and
+# scripts/build.sh do not. Running this after `make build` guarantees the
+# symlink exists for every card.
+#
+# Usage: last_elf.sh [BUILD_DIR]   (BUILD_DIR defaults to ./build)
+set -uo pipefail
+
+build_dir="${1:-build}"
+
+if [[ ! -d "$build_dir" ]]; then
+  echo "last_elf: build directory not found: $build_dir" >&2
+  exit 0
+fi
+
+build_abs="$(cd "$build_dir" && pwd)"
+
+# Newest ELF at depth <= 4 (excludes the Pico SDK boot stage2 ELF, which lives
+# deeper) and excludes the symlink itself.
+last_elf="$(find "$build_abs" -maxdepth 4 -type f -name '*.elf' ! -name '.last.elf' \
+  -printf '%T@ %p\n' 2>/dev/null | sort -nr | head -n 1 | cut -d' ' -f2-)"
+
+if [[ -z "$last_elf" ]]; then
+  echo "last_elf: no ELF found under $build_dir" >&2
+  exit 0
+fi
+
+ln -sf "$last_elf" "$build_dir/.last.elf"
+echo "last_elf: $build_dir/.last.elf -> $last_elf"

--- a/scripts/pico_auto_make.mk
+++ b/scripts/pico_auto_make.mk
@@ -1,0 +1,282 @@
+# Global Makefile include for this dev environment.
+#
+# This file is injected via the MAKEFILES environment variable (see
+# .devcontainer/devcontainer.json). It enables a convenient workflow:
+#
+#   cd Workshop_Computer/releases/<card>
+#   make
+#
+# even when that directory contains no local Makefile, as long as it looks like
+# a Pico SDK (CMake) project.
+
+SHELL := /bin/bash
+
+# Absolute path to this harness file and the dev-env repo root that contains it.
+# Captured here (rather than hardcoded) so the harness works regardless of the
+# workspace folder name or where the repo is cloned.
+PICO_AUTO_MAKE_MK := $(abspath $(lastword $(MAKEFILE_LIST)))
+DEV_ENV_ROOT := $(abspath $(dir $(PICO_AUTO_MAKE_MK))/..)
+
+# Only activate when there is NO local makefile in the current directory.
+LOCAL_MAKEFILE := $(firstword $(wildcard GNUmakefile Makefile makefile))
+ifeq ($(strip $(LOCAL_MAKEFILE)),)
+
+# Detect where the CMake project is rooted.
+# Preference order:
+#  1) ./CMakeLists.txt
+#  2) ./src/CMakeLists.txt
+#  3) first CMakeLists.txt within depth 2 (excluding build-like dirs)
+PICO_PROJECT_DIR := $(strip \
+  $(if $(wildcard CMakeLists.txt),.,\
+    $(if $(wildcard src/CMakeLists.txt),src,\
+      $(shell find . -maxdepth 2 -mindepth 2 -name CMakeLists.txt \
+        -not -path './build/*' -not -path './*/build/*' \
+        -not -path './_build/*' -not -path './*/_build/*' \
+        -not -path './cmake-build-*/*' -not -path './*/cmake-build-*/*' \
+        -print -quit 2>/dev/null | sed 's#^\\./##' | xargs -r dirname))))
+
+PICO_PROJECT_CMAKELISTS := $(if $(PICO_PROJECT_DIR),$(PICO_PROJECT_DIR)/CMakeLists.txt,)
+
+# Only treat as Pico SDK project if it either has a pico_sdk_import.cmake alongside
+# the CMakeLists.txt or references pico_sdk_import from the CMakeLists.
+PICO_IS_PICO_SDK := $(strip \
+  $(if $(PICO_PROJECT_DIR),\
+    $(shell \
+      if [[ -f "$(PICO_PROJECT_DIR)/pico_sdk_import.cmake" ]]; then echo yes; \
+      elif [[ -f "$(PICO_PROJECT_CMAKELISTS)" ]] && grep -q "pico_sdk_import" "$(PICO_PROJECT_CMAKELISTS)"; then echo yes; \
+      else echo no; fi \
+    ),\
+    no))
+
+ifeq ($(PICO_IS_PICO_SDK),yes)
+
+.DEFAULT_GOAL := all
+
+CMAKE ?= cmake
+BUILD_DIR ?= build
+CMAKE_CXX_STANDARD ?= 17
+
+# Pico SDK resolution:
+# - Respect PICO_SDK_PATH if already set.
+# - Otherwise prefer the SDK in this dev container.
+# - Otherwise fall back to the SDK built under ComputerCard_Examples (if present).
+# - Otherwise allow FetchContent via Pico SDK's standard variables.
+PICO_SDK_PATH ?= $(if $(wildcard /opt/pico-sdk/pico_sdk_init.cmake),/opt/pico-sdk,)
+WORKSPACE_PICO_SDK ?= $(DEV_ENV_ROOT)/ComputerCard_Examples/build/pico-sdk
+ifneq ($(strip $(PICO_SDK_PATH)),)
+  CMAKE_PICO_SDK_ARGS := -DPICO_SDK_PATH=$(PICO_SDK_PATH)
+else ifneq ($(wildcard $(WORKSPACE_PICO_SDK)/pico_sdk_init.cmake),)
+  CMAKE_PICO_SDK_ARGS := -DPICO_SDK_PATH=$(WORKSPACE_PICO_SDK)
+else
+  PICO_SDK_FETCH_FROM_GIT ?= ON
+  PICO_SDK_FETCH_FROM_GIT_PATH ?= $(HOME)/.pico-sdk
+  PICO_SDK_FETCH_FROM_GIT_TAG ?= master
+  CMAKE_PICO_SDK_ARGS := \
+    -DPICO_SDK_FETCH_FROM_GIT=$(PICO_SDK_FETCH_FROM_GIT) \
+    -DPICO_SDK_FETCH_FROM_GIT_PATH=$(PICO_SDK_FETCH_FROM_GIT_PATH) \
+    -DPICO_SDK_FETCH_FROM_GIT_TAG=$(PICO_SDK_FETCH_FROM_GIT_TAG)
+endif
+
+CMAKE_ARGS ?=
+PICO_BOARD_HEADER_DIRS ?= $(abspath $(PICO_PROJECT_DIR));$(abspath $(PICO_PROJECT_DIR)/..)
+
+# Toolchain resolution:
+# - Respect PICO_TOOLCHAIN_PATH if already set.
+# - Otherwise infer from arm-none-eabi-gcc on PATH.
+TOOLCHAIN_C := $(strip $(shell command -v arm-none-eabi-gcc 2>/dev/null))
+TOOLCHAIN_CXX := $(strip $(shell command -v arm-none-eabi-g++ 2>/dev/null))
+ifneq ($(TOOLCHAIN_C),)
+	TOOLCHAIN_ROOT := $(abspath $(dir $(TOOLCHAIN_C))/..)
+	PICO_TOOLCHAIN_PATH ?= $(TOOLCHAIN_ROOT)
+endif
+
+CMAKE_ARGS += -DCMAKE_EXPORT_COMPILE_COMMANDS=ON $(CMAKE_PICO_SDK_ARGS) \
+	-DCMAKE_CXX_STANDARD=$(CMAKE_CXX_STANDARD) \
+	-DCMAKE_CXX_STANDARD_REQUIRED=ON \
+	-DPICO_BOARD_HEADER_DIRS="$(PICO_BOARD_HEADER_DIRS)"
+
+# Place UF2 artifacts alongside the project CMakeLists.txt
+UF2_DIR ?= $(PICO_PROJECT_DIR)/UF2
+
+ifneq ($(strip $(PICO_TOOLCHAIN_PATH)),)
+  CMAKE_ARGS += -DPICO_TOOLCHAIN_PATH=$(PICO_TOOLCHAIN_PATH)
+endif
+
+ifneq ($(strip $(TOOLCHAIN_C)),)
+	CMAKE_ARGS += -DCMAKE_C_COMPILER=$(TOOLCHAIN_C)
+endif
+ifneq ($(strip $(TOOLCHAIN_CXX)),)
+	CMAKE_ARGS += -DCMAKE_CXX_COMPILER=$(TOOLCHAIN_CXX)
+endif
+
+NINJA := $(shell command -v ninja 2>/dev/null)
+ifneq ($(strip $(NINJA)),)
+  CMAKE_GEN_ARGS := -G "Ninja"
+else
+  CMAKE_GEN_ARGS :=
+endif
+
+.PHONY: all configure build clean distclean uf2 help .
+
+# Support the (somewhat common) "make ." habit.
+.: all
+
+all: build
+
+configure:
+	$(CMAKE) -S "$(PICO_PROJECT_DIR)" -B "$(BUILD_DIR)" $(CMAKE_GEN_ARGS) $(CMAKE_ARGS)
+
+build:
+	@set -uo pipefail; \
+	  run_build() { \
+	    "$(CMAKE)" -S "$(PICO_PROJECT_DIR)" -B "$(BUILD_DIR)" $(CMAKE_GEN_ARGS) $(CMAKE_ARGS) || return $$?; \
+	    "$(CMAKE)" --build "$(BUILD_DIR)" || return $$?; \
+	    mkdir -p "$(UF2_DIR)"; \
+	    shopt -s nullglob; \
+	    found=0; \
+	    while IFS= read -r -d '' f; do \
+	      found=1; \
+	      cp -f "$$f" "$(UF2_DIR)/"; \
+	      cwd="$$(pwd)"; \
+	      rel="$$cwd"; \
+	      rel="$${rel#/workspaces/}"; \
+	      dest="$$(cd "$(PICO_PROJECT_DIR)" && pwd)"; \
+	      dest="$${dest#/workspaces/}/UF2/$$(basename "$$f")"; \
+	      echo "UF2 copied to $$dest"; \
+	    done < <(find "$(BUILD_DIR)" -maxdepth 4 -type f -name '*.uf2' -print0 2>/dev/null); \
+	    build_abs="$$(cd "$(BUILD_DIR)" && pwd)"; \
+	    last_elf="$$(find "$$build_abs" -maxdepth 4 -type f -name '*.elf' -printf '%T@ %p\n' 2>/dev/null | sort -nr | head -n 1 | cut -d' ' -f2-)"; \
+	    if [[ -n "$$last_elf" ]]; then \
+	      ln -sf "$$last_elf" "$(BUILD_DIR)/.last.elf"; \
+	    fi; \
+	    if [[ $$found -eq 0 ]]; then \
+	      true; \
+	    fi; \
+	  }; \
+	  if run_build; then \
+	    exit 0; \
+	  fi; \
+	  echo "Build failed; cleaning and retrying once..."; \
+	  rm -rf "$(BUILD_DIR)"; \
+	  run_build
+
+clean:
+	rm -rf "$(BUILD_DIR)"
+
+distclean: clean
+
+uf2: build
+	@find "$(UF2_DIR)" -maxdepth 1 -type f -name '*.uf2' -print 2>/dev/null || true
+	@find "$(BUILD_DIR)" -maxdepth 3 -type f -name '*.uf2' -print 2>/dev/null || true
+
+# Flash via a running OpenOCD instance (typically on the host).
+#
+# Default expects OpenOCD is already running and listening for GDB on 3333:
+#   openocd -f interface/cmsis-dap.cfg -f target/rp2040.cfg -c "adapter speed 5000"
+#
+# If you run OpenOCD elsewhere, override:
+#   make flash OPENOCD_HOST=... OPENOCD_GDB_PORT=3333
+
+OPENOCD_HOST ?= host.docker.internal
+OPENOCD_GDB_PORT ?= 3333
+
+# Optional: explicitly choose an ELF to load.
+FLASH_ELF ?=
+
+# Optional: explicitly choose a UF2 (used to select which target to flash).
+# Note: OpenOCD/GDB flashes using an ELF, not a UF2.
+FLASH_UF2 ?=
+
+# GDB to use for flashing. If empty, auto-detect.
+GDB ?=
+
+
+.PHONY: flash
+
+flash: uf2
+	@set -uo pipefail; \
+	  fail() { echo "FLASH FAILED: $$*"; exit 2; }; \
+	  uf2="$(FLASH_UF2)"; \
+	  if [[ -z "$$uf2" && -d "$(UF2_DIR)" ]]; then \
+	    uf2="$$(find "$(UF2_DIR)" -maxdepth 1 -type f -name '*.uf2' -printf '%T@ %p\n' 2>/dev/null | sort -nr | head -n 1 | cut -d' ' -f2-)"; \
+	  fi; \
+	  if [[ -z "$$uf2" ]]; then \
+	    uf2="$$(find "$(BUILD_DIR)" -maxdepth 4 -type f -name '*.uf2' -printf '%T@ %p\n' 2>/dev/null | sort -nr | head -n 1 | cut -d' ' -f2-)"; \
+	  fi; \
+	  stem=""; \
+	  if [[ -n "$$uf2" ]]; then \
+	    stem="$$(basename "$$uf2" .uf2)"; \
+	  fi; \
+	  elf="$(FLASH_ELF)"; \
+	  if [[ -z "$$elf" && -f "$(BUILD_DIR)/.last.elf" ]]; then \
+	    elf="$(BUILD_DIR)/.last.elf"; \
+	  fi; \
+	  if [[ -z "$$elf" && -n "$$stem" && -f "$(BUILD_DIR)/$$stem.elf" ]]; then \
+	    elf="$(BUILD_DIR)/$$stem.elf"; \
+	  fi; \
+	  if [[ -z "$$elf" ]]; then \
+	    elf="$$(find "$(BUILD_DIR)" -maxdepth 4 -type f -name '*.elf' -printf '%T@ %p\n' 2>/dev/null | sort -nr | head -n 1 | cut -d' ' -f2-)"; \
+	  fi; \
+	  if [[ -z "$$elf" || ! -f "$$elf" ]]; then \
+	    fail "couldn't find an .elf under $(BUILD_DIR) (set FLASH_ELF=... or ensure build produced one)"; \
+	  fi; \
+	  if [[ -n "$$uf2" ]]; then \
+	    echo "Using UF2 $$uf2 (selects ELF $$elf)"; \
+	  fi; \
+	  if ! (echo >"/dev/tcp/$(OPENOCD_HOST)/$(OPENOCD_GDB_PORT)") >/dev/null 2>&1; then \
+	    echo "Start OpenOCD on the host, e.g.:" >&2; \
+	    echo "  openocd -f interface/cmsis-dap.cfg -f target/rp2040.cfg -c \"adapter speed 5000\"" >&2; \
+	    fail "cannot connect to OpenOCD GDB server at $(OPENOCD_HOST):$(OPENOCD_GDB_PORT)"; \
+	  fi; \
+	  gdb_cmd="$(GDB)"; \
+	  if [[ -z "$$gdb_cmd" ]]; then \
+	    if command -v arm-none-eabi-gdb >/dev/null 2>&1; then gdb_cmd="arm-none-eabi-gdb"; \
+	    elif command -v gdb-multiarch >/dev/null 2>&1; then gdb_cmd="gdb-multiarch"; \
+	    else \
+	      echo "Install a GDB in the devcontainer (recommended: gdb-multiarch)." >&2; \
+	      fail "no suitable GDB found in PATH (arm-none-eabi-gdb or gdb-multiarch)"; \
+	    fi; \
+	  fi; \
+	  echo "Flashing $$elf via OpenOCD at $(OPENOCD_HOST):$(OPENOCD_GDB_PORT)"; \
+	  rc=0; \
+	  for attempt in 1 2; do \
+	    if ! (echo >"/dev/tcp/$(OPENOCD_HOST)/$(OPENOCD_GDB_PORT)") >/dev/null 2>&1; then \
+	      if [[ $$attempt -eq 1 ]]; then \
+	        echo "Can't connect to OpenOCD at $(OPENOCD_HOST):$(OPENOCD_GDB_PORT); retrying once..." >&2; \
+	        sleep 1; \
+	        continue; \
+	      fi; \
+	      echo "Start OpenOCD on the host, e.g.:" >&2; \
+	      echo "  openocd -f interface/cmsis-dap.cfg -f target/rp2040.cfg -c \"adapter speed 5000\"" >&2; \
+	      fail "cannot connect to OpenOCD GDB server at $(OPENOCD_HOST):$(OPENOCD_GDB_PORT)"; \
+	    fi; \
+	    rc=0; \
+	    "$$gdb_cmd" -q -nx -batch \
+	      -ex "target extended-remote $(OPENOCD_HOST):$(OPENOCD_GDB_PORT)" \
+	      -ex "monitor reset init" \
+	      -ex "load" \
+	      -ex "monitor reset run" \
+	      -ex "detach" \
+	      "$$elf" || rc=$$?; \
+	    if [[ $$rc -eq 0 ]]; then \
+	      echo "FLASH OK"; \
+	      exit 0; \
+	    fi; \
+	    if [[ $$attempt -eq 1 ]]; then \
+	      echo "FLASH FAILED (gdb exit $$rc); retrying once..."; \
+	      sleep 0.5; \
+	    fi; \
+	  done; \
+	  echo "FLASH FAILED (gdb exit $$rc)"; \
+	  exit $$rc
+
+help:
+	@echo "PicoSDK helper (auto-enabled when no Makefile exists)"
+	@echo "Targets: build (default), clean, uf2, flash"
+	@echo "Vars: BUILD_DIR=build CMAKE=cmake PICO_SDK_PATH=/path/to/pico-sdk"
+	@echo "      PICO_SDK_FETCH_FROM_GIT=ON PICO_SDK_FETCH_FROM_GIT_PATH=\$$HOME/.pico-sdk"
+	@echo "      OPENOCD_HOST=host.docker.internal OPENOCD_GDB_PORT=3333 GDB=gdb-multiarch"
+	@echo "      FLASH_ELF=path/to.elf FLASH_UF2=UF2/name.uf2"
+
+endif # PICO_IS_PICO_SDK
+endif # no local makefile

--- a/scripts/start_openocd_host.ps1
+++ b/scripts/start_openocd_host.ps1
@@ -1,0 +1,62 @@
+<#!
+Start host-side OpenOCD for RP2040 (CMSIS-DAP), for use with the devcontainer.
+
+Usage:
+  powershell -ExecutionPolicy Bypass -File .\scripts\start_openocd_host.ps1
+  powershell -ExecutionPolicy Bypass -File .\scripts\start_openocd_host.ps1 -AdapterSpeed 2000
+
+Then from inside the container:
+  make flash
+#>
+
+[CmdletBinding()]
+param(
+  [string]$InterfaceCfg = $env:OPENOCD_INTERFACE_CFG,
+  [string]$TargetCfg = $env:OPENOCD_TARGET_CFG,
+  [int]$AdapterSpeed = $(if ($env:OPENOCD_ADAPTER_SPEED) { [int]$env:OPENOCD_ADAPTER_SPEED } else { 5000 }),
+  [int]$GdbPort = $(if ($env:OPENOCD_GDB_PORT) { [int]$env:OPENOCD_GDB_PORT } else { 3333 }),
+  [int]$GdbMaxConnections = $(if ($env:OPENOCD_GDB_MAX_CONNECTIONS) { [int]$env:OPENOCD_GDB_MAX_CONNECTIONS } else { 3 }),
+  [string]$GdbTargets = $(if ($env:OPENOCD_GDB_TARGETS) { $env:OPENOCD_GDB_TARGETS } else { "rp2040.core0 rp2040.core1" }),
+  [int]$TelnetPort = $(if ($env:OPENOCD_TELNET_PORT) { [int]$env:OPENOCD_TELNET_PORT } else { 4444 }),
+  [int]$TclPort = $(if ($env:OPENOCD_TCL_PORT) { [int]$env:OPENOCD_TCL_PORT } else { 6666 }),
+  [string[]]$ExtraArgs = @()
+)
+
+if ([string]::IsNullOrWhiteSpace($InterfaceCfg)) { $InterfaceCfg = "interface/cmsis-dap.cfg" }
+if ([string]::IsNullOrWhiteSpace($TargetCfg)) { $TargetCfg = "target/rp2040.cfg" }
+
+$openocd = Get-Command openocd -ErrorAction SilentlyContinue
+if (-not $openocd) {
+  Write-Error "openocd not found on PATH. Install OpenOCD on the host."
+  exit 127
+}
+
+Write-Host "Starting OpenOCD (host)..."
+Write-Host "  interface:   $InterfaceCfg"
+Write-Host "  target:      $TargetCfg"
+Write-Host "  speed (kHz): $AdapterSpeed"
+Write-Host "  gdb_port:    $GdbPort"
+Write-Host "  gdb_max:     $GdbMaxConnections"
+Write-Host "  gdb_targets: $GdbTargets"
+Write-Host "  telnet_port: $TelnetPort"
+Write-Host "  tcl_port:    $TclPort"
+
+$gdbMaxArgs = @()
+foreach ($targetName in ($GdbTargets -split '\s+')) {
+  if (-not [string]::IsNullOrWhiteSpace($targetName)) {
+    $gdbMaxArgs += @('-c', "$targetName configure -gdb-max-connections $GdbMaxConnections")
+  }
+}
+
+$openocdArgs = @(
+  '-f', $InterfaceCfg,
+  '-f', $TargetCfg,
+  '-c', "adapter speed $AdapterSpeed",
+  $gdbMaxArgs,
+  '-c', "gdb_port $GdbPort",
+  '-c', "telnet_port $TelnetPort",
+  '-c', "tcl_port $TclPort"
+) + $ExtraArgs
+
+& $openocd.Source @openocdArgs
+exit $LASTEXITCODE

--- a/scripts/start_openocd_host.sh
+++ b/scripts/start_openocd_host.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Start host-side OpenOCD for RP2040 (CMSIS-DAP), for use with the devcontainer.
+
+Usage:
+  ./scripts/start_openocd_host.sh [options] [-- <extra-openocd-args...>]
+
+Options:
+  --interface <cfg>     OpenOCD interface cfg (default: interface/cmsis-dap.cfg)
+  --target <cfg>        OpenOCD target cfg (default: target/rp2040.cfg)
+  --speed <khz>         Adapter speed in kHz (default: 5000)
+  --gdb-port <port>     GDB port (default: 3333)
+  --gdb-max <count>     Max GDB connections (default: 3)
+  --gdb-targets <names> OpenOCD target names for GDB max setting
+                        (default: "rp2040.core0 rp2040.core1")
+  --telnet-port <port>  Telnet port (default: 4444)
+  --tcl-port <port>     TCL port (default: 6666)
+
+Environment (equivalent defaults):
+  OPENOCD_INTERFACE_CFG, OPENOCD_TARGET_CFG, OPENOCD_ADAPTER_SPEED,
+  OPENOCD_GDB_PORT, OPENOCD_GDB_MAX_CONNECTIONS, OPENOCD_GDB_TARGETS,
+  OPENOCD_TELNET_PORT, OPENOCD_TCL_PORT
+
+Examples:
+  ./scripts/start_openocd_host.sh
+  ./scripts/start_openocd_host.sh --speed 2000
+  ./scripts/start_openocd_host.sh -- --log_output openocd.log
+
+Then from inside the container:
+  make flash
+EOF
+}
+
+if ! command -v openocd >/dev/null 2>&1; then
+  echo "Error: openocd not found on PATH. Install OpenOCD on the host." >&2
+  exit 127
+fi
+
+interface_cfg="${OPENOCD_INTERFACE_CFG:-interface/cmsis-dap.cfg}"
+target_cfg="${OPENOCD_TARGET_CFG:-target/rp2040.cfg}"
+adapter_speed="${OPENOCD_ADAPTER_SPEED:-5000}"
+gdb_port="${OPENOCD_GDB_PORT:-3333}"
+gdb_max_connections="${OPENOCD_GDB_MAX_CONNECTIONS:-3}"
+gdb_targets="${OPENOCD_GDB_TARGETS:-rp2040.core0 rp2040.core1}"
+telnet_port="${OPENOCD_TELNET_PORT:-4444}"
+tcl_port="${OPENOCD_TCL_PORT:-6666}"
+
+extra_args=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --interface)
+      interface_cfg="$2"; shift 2
+      ;;
+    --target)
+      target_cfg="$2"; shift 2
+      ;;
+    --speed)
+      adapter_speed="$2"; shift 2
+      ;;
+    --gdb-port)
+      gdb_port="$2"; shift 2
+      ;;
+    --gdb-max)
+      gdb_max_connections="$2"; shift 2
+      ;;
+    --gdb-targets)
+      gdb_targets="$2"; shift 2
+      ;;
+    --telnet-port)
+      telnet_port="$2"; shift 2
+      ;;
+    --tcl-port)
+      tcl_port="$2"; shift 2
+      ;;
+    --)
+      shift
+      extra_args+=("$@")
+      break
+      ;;
+    *)
+      extra_args+=("$1")
+      shift
+      ;;
+  esac
+done
+
+echo "Starting OpenOCD (host)..."
+echo "  interface:   $interface_cfg"
+echo "  target:      $target_cfg"
+echo "  speed (kHz): $adapter_speed"
+echo "  gdb_port:    $gdb_port"
+echo "  gdb_max:     $gdb_max_connections"
+echo "  gdb_targets: $gdb_targets"
+echo "  telnet_port: $telnet_port"
+echo "  tcl_port:    $tcl_port"
+
+gdb_max_args=()
+for target_name in $gdb_targets; do
+  gdb_max_args+=(-c "$target_name configure -gdb-max-connections $gdb_max_connections")
+done
+
+if [[ ${#extra_args[@]} -gt 0 ]]; then
+  exec openocd \
+    -f "$interface_cfg" \
+    -f "$target_cfg" \
+    -c "adapter speed $adapter_speed" \
+    "${gdb_max_args[@]}" \
+    -c "gdb_port $gdb_port" \
+    -c "telnet_port $telnet_port" \
+    -c "tcl_port $tcl_port" \
+    "${extra_args[@]}"
+else
+  exec openocd \
+    -f "$interface_cfg" \
+    -f "$target_cfg" \
+    -c "adapter speed $adapter_speed" \
+    "${gdb_max_args[@]}" \
+    -c "gdb_port $gdb_port" \
+    -c "telnet_port $telnet_port" \
+    -c "tcl_port $tcl_port"
+fi


### PR DESCRIPTION
Definitely need reviews here as I am no expert on this stuff. I've confirmed make all works in the new container.

.vscode id gitignored so my tasks etc from dev env are not here but I think that's fine (lmk if you disagree).

Adding devcontainer to Workshop_Computer is part of the ongoing pipeline / card deployment work. Making the devcontainer more mainstream makes it easy for us to get custom tooling in front of developers and make life easier, particularly for new devs.