### PR TITLE
fix for generated readme table

### DIFF
--- a/.github/scripts/update-readme.py
+++ b/.github/scripts/update-readme.py
@@ -3,7 +3,7 @@ import sys
 import yaml
 
 sys.path.insert(0, os.path.dirname(__file__))
-from web_editor_resolve import readme_editor_url, github_pages_base
+from web_editor_resolve import readme_editor_url, github_pages_base, normalize_card_info
 
 # Define the base folder and README file path
 base_folder = 'releases'
@@ -15,7 +15,14 @@ pages_base = github_pages_base(repo_slug)
 # Function to read data from a YAML file
 def read_data(file_path):
     with open(file_path, 'r') as file:
-        return yaml.safe_load(file)
+        data = yaml.safe_load(file)
+    return data if isinstance(data, dict) else {}
+
+
+def read_card_info(folder_path):
+    info_path = os.path.join(folder_path, 'info.yaml')
+    if os.path.isfile(info_path):
+        return read_data(info_path)
     return {}
 
 # Function to update the README file
@@ -23,14 +30,8 @@ def update_readme(folders_data):
     # Define the desired order of columns
     desired_order = ['Description', 'Version', 'Language', 'Creator']
 
-    # Identify all unique keys to ensure all columns are included
-    all_keys = set()
-    for data in folders_data.values():
-        all_keys.update(data.keys())
-    all_keys = sorted(all_keys)
-
-    # Only show desired columns
-    ordered_keys = [key for key in desired_order if key in all_keys]
+    # Standard table columns
+    ordered_keys = desired_order
 
     # Create new table headers and dividers
     headers = ['Folder Name'] + ordered_keys
@@ -42,19 +43,21 @@ def update_readme(folders_data):
     # Create table rows
     sorted_folders = sorted(folders_data.keys())
     for folder in sorted_folders:
-        d = folders_data[folder]
+        raw = folders_data[folder]
+        d = normalize_card_info(raw)
         row = [folder]
-        descr = d.get('Description','')
-        editor_url = readme_editor_url(folder, os.path.join(base_folder, folder), d, pages_base)
+        descr = str(d.get('description') or d.get('summary') or '')
+        editor_url = readme_editor_url(folder, os.path.join(base_folder, folder), raw, pages_base)
         if editor_url:
             descr += '<br>[Web editor](' + editor_url + ')'
         row += [descr]
-        vers = str(d.get('Version',''))
-        if 'Status' in d:
-            vers += '<br>'+d.get('Status','')
+        vers = '' if d.get('version') is None else str(d.get('version'))
+        status = d.get('status')
+        if status not in (None, ''):
+            vers += '<br>' + str(status)
         row += [vers]
-        row += [d.get('Language','')]
-        row += [d.get('Creator','')]
+        row += [str(d.get('language') or '')]
+        row += [str(d.get('creator') or '')]
         new_table.append('| ' + ' | '.join(row) + ' |\n')
 
     # Write the new content to the README.md file
@@ -67,14 +70,7 @@ def main():
     for folder in os.listdir(base_folder):
         folder_path = os.path.join(base_folder, folder)
         if os.path.isdir(folder_path):
-            data = {}
-            for file in os.listdir(folder_path):
-                file_path = os.path.join(folder_path, file)
-                if file.endswith('.yaml') or file.endswith('.yml'):
-                    file_data = read_data(file_path)
-                    data.update(file_data)
-                    break
-            folders_data[folder] = data
+            folders_data[folder] = read_card_info(folder_path)
 
     update_readme(folders_data)
 

--- a/.github/scripts/web_editor_resolve.py
+++ b/.github/scripts/web_editor_resolve.py
@@ -27,6 +27,24 @@ def _normalize_info(data):
     return {_key(k): v for k, v in data.items()}
 
 
+def normalize_card_info(data):
+    """Flatten info.yaml to canonical lowercase keys (mirrors sitegen + metadata block)."""
+    if not data or not isinstance(data, dict):
+        return {}
+    out = _normalize_info(data)
+    meta = out.get('metadata')
+    if isinstance(meta, dict):
+        for k, v in _normalize_info(meta).items():
+            if k not in out or out[k] in (None, ''):
+                out[k] = v
+    if not out.get('editor'):
+        for alias in ('editorurl', 'editor_url'):
+            if out.get(alias):
+                out['editor'] = out[alias]
+                break
+    return out
+
+
 def _is_url(s):
     return bool(re.match(r'^https?://', str(s or '').strip(), re.I))
 
@@ -51,19 +69,15 @@ def _local_url(card_path, slug, rel_folder, web_entry, pages_base):
 
 
 def _editor_from_data(data):
-    """Raw Editor value from info.yaml (any key casing)."""
-    if not data:
-        return ''
-    for key, val in data.items():
-        if _key(key) == 'editor':
-            return str(val or '').strip()
-    return ''
+    """Raw Editor value from info.yaml (any key casing, including metadata.editor_url)."""
+    info = normalize_card_info(data)
+    return str(info.get('editor') or '').strip()
 
 
 def resolve_editor_url(folder_name, card_path, data, pages_base=None):
     """Return editor URL for sitegen (external, local path, or auto web/)."""
     pages_base = pages_base or DEFAULT_PAGES_BASE
-    info = _normalize_info(data)
+    info = normalize_card_info(data)
     slug = slugify(folder_name)
     editor = str(info.get('editor') or '').strip()
     web_entry = str(info.get('webentry') or '').strip()
@@ -88,4 +102,10 @@ def readme_editor_url(folder_name, card_path, data, pages_base=None):
         return ''
     if editor and _is_url(editor):
         return editor
+    if editor and not _is_url(editor):
+        editor_path = os.path.normpath(os.path.join(card_path, editor))
+        if os.path.isfile(editor_path):
+            repo = os.environ.get('GITHUB_REPOSITORY', 'TomWhitwell/Workshop_Computer')
+            rel = os.path.relpath(editor_path, '.').replace(os.sep, '/')
+            return f'https://github.com/{repo}/blob/main/{rel}'
     return resolve_editor_url(folder_name, card_path, data, pages_base)

--- a/releases/README.md
+++ b/releases/README.md
@@ -24,14 +24,14 @@
 | 23_SlowMod | Chaotic quad-LFO with VCAs | 0.1<br>Released | C++ (RPi Pico SDK) compat. w/ cmake and Arduino IDE. | divmod |
 | 24_crafted_volts | Manually set control voltages (CV) with the input knobs and switch. It also attenuverts (attenuates and inverts) incoming voltages. | (see source repo)<br>Released | Rust (Embassy framework) | Brian Dorsey |
 | 25_utility_pair | 25 small utilities, which can be combined in pairs | 1.0<br>Released | C++ (ComputerCard) | Chris Johnson |
-| 26_clockwork | <br>[Web editor](https://vincentmaurer.de/clockwork/index.html) |  |  | Vincent Maurer |
+| 26_clockwork | 6-channel polyrhythmic clock, gate, and LFO/envelope generator inspired by Pamela's Workout.<br>[Web editor](https://vincentmaurer.de/clockwork/index.html) | 1.0.0<br>Released | C++ (RP2040 Pico SDK) | Vincent Maurer |
 | 27_Siren | Multi-algorithm drone oscillator. Inspired by the Forge TME Vhikk X. | 0.2<br>Functional but WIP | C++ (ComputerCard / Pico SDK) | Moses Hoyt |
 | 28_eighties_bass | Bass-oriented complete monosynth voice consisting of five detuned saw wave oscillators with mixable white noise and adjustable resonant filter. | 0.1<br>Functional but WIP | Arduino (arduino-pico) with Mozzi 2 | Tod Kurt (@todbot) |
 | 30_cirpy_wavetable | Wavetable oscillator that using wavetables from Plaits, Braids, and Microwave, | 0.1<br>Functional but WIP | CircuitPython | Tod Kurt (@todbot) |
 | 31_esp | A MS-20-style External Signal Processor that includes a preamp, bandpass filter, envelope follower, gate, and 1v/oct pitch outs. | 1.0<br>Released | C++ (ComputerCard) | Ben Regnier |
 | 32_vink | Dual delay loops with sigmoid saturation for Jaap Vink / Roland Kayn style feedback patching | 1.1<br>Functional | C++ (ComputerCard) | Ben Regnier |
 | 33_drumdrum | DFAM-style 8-step sequencer<br>[Web editor](https://mohoyt.com/drumdrum.html) | 1.2.0<br>Functional but WIP | C++ (ComputerCard / Pico SDK) | Moses Hoyt |
-| 34_dual_quant |  |  |  |  |
+| 34_dual_quant | Dual quantised granular pitch shifter with calibrated 1V/oct CV outputs | 1<br>Beta | C++ (ComputerCard / Pico SDK) | Adrian Vos |
 | 35_FreqShift | Dual Input Frequency Shifter for Feedback Experimentation | 1.1<br>Functional | C++ (ComputerCard) | Ben Regnier |
 | 36_GradualProcess | Three generative composition processes (Glass, Reich, Tintinnabuli) in one card, chosen by Main's position at power-on | 1.0.0<br>Released | C++ (ComputerCard) | James Saunders |
 | 37_compulidean | Generative Euclidean drum + sample player. | (see source repo)<br>Functional, but WIP | C++/Arduino, with vscode+platformio. | Tristan Rowley |
@@ -39,39 +39,39 @@
 | 39_knots | Six-engine oscillator firmware for the Music Thing Workshop System | 0.2<br>Released | C++ (RPi Pico SDK / ComputerCard) | Jeff Fletcher |
 | 41_blackbird | A scriptable, live-codable, USB-serial-to-CV device implementing monome crow's protocol<br>[Web editor](https://dessertplanet.github.io/web-druid/) | 1.1<br>Released | Pico SDK + Lua | Dune Desormeaux |
 | 42_backyard_rain | Nature soundscape audio. A cozy rain ambience mix for background listening. You control the intensity. This card plays rain ambience which was recorded in my backyard. | (see source repo)<br>Released | Rust (Embassy framework) | Brian Dorsey |
-| 43_Castle_Process | Fort Processor-inspired harsh noise processor with chopped external audio and a bass pulse voice |  | C++ | Adrian Vos |
-| 43_clockwork | <br>[Web editor](https://vincentmaurer.de/clockwork/index.html) |  |  | Vincent Maurer |
+| 43_Castle_Process | Fort Processor-inspired harsh noise processor with chopped external audio and a bass pulse voice | 1.0<br>Release Candidate | C++ | Adrian Vos |
+| 43_clockwork | 6-channel polyrhythmic clock, gate, and LFO/envelope generator inspired by Pamela's Workout.<br>[Web editor](https://vincentmaurer.de/clockwork/index.html) | 1.0.0<br>Released | C++ (RP2040 Pico SDK) | Vincent Maurer |
 | 44_Birds | Two birds sing to each other controlled by a Turing-style shift register sequencer with clock in and CV/pulse out. | 0.5.0<br>Beta | C++ (Pico SDK / ComputerCard) | Tom Whitwell |
 | 47_NZT | Grain Noise and Noise Tools | 1.0.0<br>Released | C++ (ComputerCard) | @kjnilsson |
 | 50_flux | Effects, Synthesizer and Utility<br>[Web editor](https://vincentmaurer.de/flux/flux_manager.html) | 1.0<br>Released | C++ (RP2040 Pico SDK) | Vincent Maurer |
 | 51_grains | Granular Sampler and Effect<br>[Web editor](https://vincentmaurer.de/grains/grains_manager.html) | 1.0<br>Released | C++ (RP2040 Pico SDK) | Vincent Maurer |
 | 53_glitter | Granular Looping Sampler | 0.1.2-beta<br>Beta | C++ (Pico SDK 2.1.1, UF2 release) | Steve Jones |
-| 54_Tapegrade |  |  |  |  |
+| 54_Tapegrade | Mono-input stereo cassette warble processor with wow, flutter, hiss, crackle, and tape wear morphing. | 0.8.0<br>WIP (functional) | C++ (RP2040 Pico SDK) | Adrian Vos |
 | 55_fifths | A quantizer/sequencer that can create harmony and nimbly traverse the circle of fifths in attempts to make jazz | 1.1<br>Released | C++ (RP2040 Pico SDK) | Dune Desormeaux |
 | 56_Krell | Krell | 1.0<br>Mostly complete | Blackbird Lua | Benjamin Reily |
 | 57_glitch | Clock-synced beat-repeater with ratcheting, reversal and audio degradation | 1.4.0<br>Released | C++ (RP2040 Pico SDK) | Andy Jenkinson (uglifruit) |
-| 58_LoChoVibes |  |  |  |  |
-| 59_BitPhase |  |  |  |  |
+| 58_LoChoVibes | Stereo chorus and vibrato effect featuring triangle, sine, and slow drift LFO modes, modulation-based delay movement, and tape-style saturation. | 0.1.0<br>released | C++ | Adrian Vos |
+| 59_BitPhase | Resonant 4-stage phaser for the Workshop Computer with deep notch filtering, wide modulation sweeps, controllable resonance, tremolo blending, and digital Burst-mode degradation. | 0.1.0<br>Beta | C++ (Pico SDK) | Adrian Vos |
 | 60_markov | Dual generative Markov chain module — evolving melody (MarkoV) left side, rhythmic percussion patterns (MarkovPerc) right side, with internal synth voice | 1.0.0<br>Released | C++ (Pico SDK) | Andy Jenkinson (uglifruit) |
 | 64_voices_of_sid | Dual MOS 6581 SID emulation (reSID engine) with CV/gate control, stereo output, waveform selection, and randomize | 1.1<br>Released | C++ (Pico SDK) | Joep Vermaat |
 | 66_stretchcore | A card for playing and manipulating samples with tempo control, timestretch with browser-based audio loading (infinitedigits.com/stretchcore/)<br>[Web editor](https://infinitedigits.co/stretchcore/) | 1.0<br>Ready% | C++ (Pico SDK) | Infinite Digits |
 | 69_trace | Oscillograph stereo oscillator | 0.1<br>Functional but WIP | C++ (ComputerCard) | Ruiyang Wang |
 | 71_degenerator | Degenerator — Disintegrating Looper. Capture audio loops and apply irreversible degradation with 6 algorithms (Saturation, Filter Drift, Tape Hiss, Oxide Shedding, Bit Crush, Bit Rot) via preview/apply workflow. Inspired by William Basinski's The Disintegration Loops.<br>[Web editor](https://degenerator-web.netlify.app/) | 1.3<br>Released | C++ (Pico SDK) | Joep Vermaat |
 | 72_motorik | Motorik drum machine — kick/snare/hihat with bass and melody CV, classic Krautrock grooves | 1.0<br>Released | C++ (Pico SDK) | Joep Vermaat |
-| 74_Wild_Pebble |  |  |  |  |
+| 74_Wild_Pebble | MIDI-clockable generative rhythm and melody organism inspired by Pet Rock | 1<br>Beta. USB MIDI clock input and sequencer note output tested | C++ | Adrian Vos with Vibecode support |
 | 76_hot_fuzz | A stereo fuzz/distortion + resonant wah effects processor with manual and auto-wah modes, built on fixed-point DSP. | 1.0<br>Released | C++ (ComputerCard) | Joep Vermaat |
 | 77_Placeholder | Reserved for secret project | 0.0<br>None | None | None |
 | 78_Talker | Proof of concept speech synthesizer, based on TalkiePCM, inspired by 1970s LPC speech synths. | 0.1<br>Proof of concept | C++ (ComputerCard) | Chris Johnson |
 | 81_West_Coast_LPG | Dual vactrol-emulating low-pass gate (combined VCA + low-pass filter) with fast-attack/slow-decay 'plong', self-pinging percussion, and per-channel VCA/VCF/LPG modes. | 0.1<br>Working | C++ (ComputerCard) | Jason Moore |
 | 82_Computer_Grids | Grids-inspired trigger sequencer with Web MIDI SysEx configuration.<br>[Web editor](https://tomwhitwell.github.io/Workshop_Computer/programs/82-computer-grids/web/index.html) | 0.1.0<br>Released | C++ | Phil Miller |
 | 83_Origami | Dual oversampled wavefolder — triangle / sine / hard-clip folding with bias (even-harmonic) control and CV over fold depth, band-limited via 4x oversampling. | 0.1<br>Working | C++ (ComputerCard) | Jason Moore |
-| 84_CosmikC1zzl3 |  |  |  |  |
+| 84_CosmikC1zzl3 | Stable phase-distortion synthesiser and Turing machine firmware with Web MIDI envelope readback, PD, detune, eight waveform families, hosted CZ patch import, USB MIDI device/host operation, and optional Turing MIDI output.<br>[Web editor](https://soveda.github.io/CozmikC1zzl3/web-midi/editor/) | 1.1<br>Released | C++ (Pico SDK) | Adrian Vos |
 | 86_tesserae | Tesserae — Variable-voice (2-8) arpeggiated chord generator with 5 patterns, 10 scales, tap tempo, CV/audio transpose inputs, and dual CV + audio pitch outputs. Inspired by Laurie Spiegel's Music Mouse and Patchwork. | 1.0<br>released | C++ (Pico SDK) | Joep Vermaat |
-| 87_fr330hfr33 |  |  |  |  |
+| 87_fr330hfr33 | Hardware-tested acid bass synthesiser with selectable saw or square oscillator, switchable 18 or 24 dB diode-style filtering, accent and glide, distortion, USB MIDI device/host operation, and a persistent editable sequencer.<br>[Web editor](https://github.com/TomWhitwell/Workshop_Computer/blob/main/releases/87_fr330hfr33/web_config/Fr330hfr33.html) | 0.9.3<br>Stable | Pico SDK | Adrian Vos |
 | 88_Blank | Reserved for blank 88 cards | 0<br>None | None | Tom Whitwell |
 | 90_Pantograph | Trace and record CV — record knob movements, loop them at bipolar speed | 1.0<br>Ready | Pico SDK | Kenny Shen |
 | 91_chorgan | Chorgan — 6-voice chord synthesizer with morphing timbre, chord extension presets, and built-in chord sequencer. Two modes: normal (detune/chorus) and slew (portamento chord changes). Inspired by the Music Thing Modular Chord Organ. | 1.1.0<br>released | C++ (Pico SDK / ComputerCard) | Andy Jenkinson (uglifruit) |
-| 93_Turing_Matrix | <br>[Web editor](https://tomwhitwell.github.io/Workshop_Computer/programs/93-turing-matrix/web/index.html) |  |  |  |
+| 93_Turing_Matrix | Turing Machine sequencer with a switchable mixer layer inspired by the Music Thing Modular Turing Machine and Vactrol Mix combination<br>[Web editor](https://soveda.github.io/Turing_Matrix_Editor/web) | 0.1.0-beta<br>Beta release candidate | C++ (ComputerCard) | Adrian Vos from initial code by Tom Whitwell / Music Thing Modular / Chris Johnson |
 | 95_offair2 | OffAir — AM/Shortwave/Longwave radio simulator. Tune between two Stations and interference with authentic heterodyne whistles, SSB pitch-shift detuning, AM envelope detection, swelling per-band static, and triggerable Insta-ference one-shots. Baked recordings or live audio inputs become the Stations. | 1.0.1<br>released | C++ (Pico SDK / ComputerCard) | Andy Jenkinson (uglifruit) |
 | 96_cathode | Composite video synthesiser (PAL + NTSC builds) — oscilloscope, etch-a-sketch & spectrum analyser, greyscale via dithering, performance effects, 8 alt-boot screensaver/game modes | 1.2.0<br>Released | C++ (RP2040 Pico SDK) | Andy Jenkinson (uglifruit) |
 | 98_duo_midi | A duophonic midi device/host interface | 0.1<br>Released | Lua / Blackbird | Dune Desormeaux |


### PR DESCRIPTION
**Problem:** Recently merged program cards (e.g. `34_dual_quant`, `54_Tapegrade`, `93_Turing_Matrix`) showed up in [`releases/README.md`](https://github.com/TomWhitwell/Workshop_Computer/blob/main/releases/README.md) with blank Description / Version / Language / Creator columns.

**Root cause:** The table is auto-generated by `.github/scripts/update-readme.py` on push to `main`. That script expected the **legacy** `info.yaml` shape (top-level `Description`, `Version`, etc.). Newer cards use **lowercase keys** and nest those fields under `metadata:` — so the generator read the files but couldn't map the fields.

**Fix:** Updated `update-readme.py` and `web_editor_resolve.py` to:
- Read `info.yaml` explicitly
- Normalize keys case-insensitively (aligned with sitegen docs)
- Flatten `metadata:` into table columns
- Honor `metadata.editor_url` for Web editor links

**Result:** All 7 previously empty rows populate correctly. Partial rows (e.g. `26_clockwork`, `93_Turing_Matrix`) are now complete.

**Follow-up (optional):** `tools/sitegen` still doesn't flatten `metadata:` — GitHub Pages card index may show the same gaps until that's aligned.
