### PR TITLE
Guard update-readme failing on git push due to successive merges

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -6,6 +6,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: update-readme
+  cancel-in-progress: true
+
 jobs:
   update-readme:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Address failures on Github Actions like https://github.com/TomWhitwell/Workshop_Computer/actions/runs/29168541824/job/86585775892 when successive merges happens.