### PR TITLE
Fix failing Github Pages workflow

### DIFF
--- a/releases/67_Fragments/info.yaml
+++ b/releases/67_Fragments/info.yaml
@@ -4,4 +4,5 @@ Language: C++ (RPi Pico SDK)
 Creator: Max Harnishfeger
 Version: 1.0
 Status: Released
-Editor: web/fragments_librarian.html
+Editor: web
+web-entry: fragments_librarian.html


### PR DESCRIPTION
@TomWhitwell  @MHarnishfeger-WM I think the `Editor` field expects a folder (`web` or `dist`) or an external URL, so the actual file needs to be placed in `web-entry`. The workflow that's generating pages is failing because it finds a filepath now.