### PR TITLE
Backfill card release dates recently clobbered by bulk update

### DIFF
--- a/releases/00_Simple_MIDI/info.yaml
+++ b/releases/00_Simple_MIDI/info.yaml
@@ -5,6 +5,7 @@ Language: Arduino-Pico
 Creator: Tom Whitwell
 Version: 0.6.6
 Status: Working but simple
+date: 2024-11-30
 
 tags:
   - midi

--- a/releases/02_comingsoon/info.yaml
+++ b/releases/02_comingsoon/info.yaml
@@ -5,3 +5,4 @@ Language: None
 Creator: None
 Version: 0.0
 Status: None
+date: 2026-06-14

--- a/releases/03_Turing_Machine/info.yaml
+++ b/releases/03_Turing_Machine/info.yaml
@@ -6,6 +6,7 @@ Creator: Tom Whitwell
 Version: 1.5.3
 Status: Working but Simple
 Editor: https://www.musicthing.co.uk/web_config/turing.html
+date: 2024-11-30
 
 tags:
   - sequencer

--- a/releases/04_BYO_Benjolin/info.yaml
+++ b/releases/04_BYO_Benjolin/info.yaml
@@ -5,6 +5,7 @@ Language: Pico SDK
 Creator: Dune Desormeaux
 Version: 1.1
 Status: Released
+date: 2025-03-23
 
 demo-link: https://www.youtube.com/watch?v=YlDGwEaBheQ
 

--- a/releases/05_chord_blimey/info.yaml
+++ b/releases/05_chord_blimey/info.yaml
@@ -5,6 +5,7 @@ Language: C (RPi Pico SDK)
 Creator: Tom Waters
 Version: 0.9
 Status: Mostly complete (for now)
+date: 2024-11-30
 
 tags:
   - arpeggiator

--- a/releases/06_usb_audio/info.yaml
+++ b/releases/06_usb_audio/info.yaml
@@ -6,6 +6,7 @@ Creator: Vincent Maurer (vincentmaurer.de)
 Version: 1.0
 Status: Release
 License: GPL-3.0
+date: 2026-01-23
 Editor: https://vincentmaurer.de/usb-audio/midi_config.html
 
 tags:

--- a/releases/07_bumpers/info.yaml
+++ b/releases/07_bumpers/info.yaml
@@ -5,6 +5,7 @@ Language: C++ (ComputerCard)
 Creator: Chris Johnson
 Version: 1.0
 Status: Released
+date: 2025-04-28
 
 tags:
   - trigger

--- a/releases/08_bytebeat/info.yaml
+++ b/releases/08_bytebeat/info.yaml
@@ -5,6 +5,7 @@ Language: C++/Arduino-Pico
 Creator: Matt Kuebrich
 Version: 0.1
 Status: Functional but WIP
+date: 2024-11-30
 
 tags:
   - bytebeat

--- a/releases/09_DivCom/info.yaml
+++ b/releases/09_DivCom/info.yaml
@@ -6,6 +6,7 @@ Creator: divmod
 Version: 0.1
 Status: Released
 Repository: https://github.com/divmod-audio/divcom
+date: 2026-05-20
 
 tags:
   - comparator

--- a/releases/10_twists/info.yaml
+++ b/releases/10_twists/info.yaml
@@ -5,6 +5,7 @@ Language: C (RPi Pico SDK)
 Creator: Random Works
 Version: 0.1
 Status: Functional but WIP
+date: 2024-11-30
 
 tags:
   - synthesizer

--- a/releases/11_goldfish/info.yaml
+++ b/releases/11_goldfish/info.yaml
@@ -6,6 +6,7 @@ Creator: Dune Desormeaux
 Version: 2.0
 Status: Released
 demo-link: https://youtu.be/pdzMC6afrHY
+date: 2025-01-25
 
 tags:
   - delay

--- a/releases/12_am_coupler/info.yaml
+++ b/releases/12_am_coupler/info.yaml
@@ -5,6 +5,7 @@ Language: C++ (ComputerCard)
 Creator: Chris Johnson
 Version: 1.0
 Status: Released
+date: 2025-05-26
 
 tags:
   - radio

--- a/releases/13_noisebox/info.yaml
+++ b/releases/13_noisebox/info.yaml
@@ -6,6 +6,7 @@ Creator: Eric Gao
 Version: 1.0
 Status: Released
 License: CC BY-NC-SA 3.0
+date: 2026-06-14
 
 tags:
   - noise

--- a/releases/14_cvmod/info.yaml
+++ b/releases/14_cvmod/info.yaml
@@ -6,6 +6,7 @@ Creator: Chris Johnson
 Version: 1.0
 Status: Released
 License: MIT
+date: 2025-05-26
 
 tags:
   - cv

--- a/releases/15_MLRws/info.yaml
+++ b/releases/15_MLRws/info.yaml
@@ -6,6 +6,7 @@ Creator: Dune Desormeaux
 Version: 1.1.5
 Status: Released
 License: GPL-3.0
+date: 2026-05-26
 Editor: https://dessertplanet.github.io/MLRws-web/
 demo-link: https://youtu.be/fhHJykM1GWk
 

--- a/releases/16_the_bells/info.yaml
+++ b/releases/16_the_bells/info.yaml
@@ -5,6 +5,7 @@ Language: C++ (ComputerCard)
 Creator: James Saunders
 Version: 1.0.0
 Status: Released
+date: 2026-07-04
 
 tags:
   - sequencer

--- a/releases/17_COMET/info.yaml
+++ b/releases/17_COMET/info.yaml
@@ -6,6 +6,7 @@ Creator: EME
 Version: 1.0
 Status: Released
 License: MIT
+date: 2026-07-13
 
 tags:
   - effect

--- a/releases/18_chord_organ/info.yaml
+++ b/releases/18_chord_organ/info.yaml
@@ -5,6 +5,7 @@ Language: Pico SDK (C++), ComputerCard
 Creator: jkeyworth
 Version: 0.1
 Status: Working
+date: 2026-02-15
 
 tags:
   - synthesizer

--- a/releases/20_reverb/info.yaml
+++ b/releases/20_reverb/info.yaml
@@ -6,6 +6,7 @@ Creator: Chris Johnson
 Version: 1.5
 Status: Released
 Editor: https://www.musicthing.co.uk/web_config/reverb.html
+date: 2024-11-30
 
 tags:
   - effect

--- a/releases/21_resonator/info.yaml
+++ b/releases/21_resonator/info.yaml
@@ -6,6 +6,7 @@ Creator: Johan Eklund
 Version: 1.2
 Status: Released
 Editor: https://johaneklund.io/resonator
+date: 2026-04-10
 
 tags:
   - effect

--- a/releases/22_sheep/info.yaml
+++ b/releases/22_sheep/info.yaml
@@ -6,6 +6,7 @@ Creator: Dune Desormeaux
 Version: 1.2
 Status: Released
 demo-link: https://youtu.be/LfkgfMzVabg
+date: 2025-07-13
 
 tags:
   - effect

--- a/releases/23_SlowMod/info.yaml
+++ b/releases/23_SlowMod/info.yaml
@@ -6,6 +6,7 @@ Creator: divmod
 Version: 0.1
 Status: Released
 Repository: https://github.com/divmod-audio/slowmod
+date: 2025-01-20
 
 tags:
   - modulation

--- a/releases/24_crafted_volts/info.yaml
+++ b/releases/24_crafted_volts/info.yaml
@@ -6,6 +6,7 @@ Creator: Brian Dorsey
 Version: (see source repo)
 Status: Released
 Repository: https://codeberg.org/briandorsey/mtmws_cards/src/branch/main/crafted_volts
+date: 2025-01-20
 
 tags:
   - utility

--- a/releases/25_utility_pair/info.yaml
+++ b/releases/25_utility_pair/info.yaml
@@ -6,6 +6,7 @@ Creator: Chris Johnson
 Version: 1.0
 Status: Released
 License: MIT
+date: 2025-01-21
 Repository: https://github.com/chrisgjohnson/Utility-Pair
 
 tags:

--- a/releases/26_clockwork/info.yaml
+++ b/releases/26_clockwork/info.yaml
@@ -5,6 +5,7 @@ release: 26 / 1.0.0
 Creator: Vincent Maurer
 Editor: https://vincentmaurer.de/clockwork/index.html
 demo-link: https://www.youtube.com/watch?v=WFxAQ-dK7CM
+date: 2026-06-29
 contact:
   website: https://vincentmaurer.de
 summary: >-

--- a/releases/27_Siren/info.yaml
+++ b/releases/27_Siren/info.yaml
@@ -6,6 +6,7 @@ Creator: Moses Hoyt
 Version: 0.2
 Status: Functional but WIP
 License: MIT
+date: 2026-03-25
 
 tags:
   - drone

--- a/releases/28_eighties_bass/info.yaml
+++ b/releases/28_eighties_bass/info.yaml
@@ -5,6 +5,7 @@ Language: Arduino (arduino-pico) with Mozzi 2
 Creator: Tod Kurt (@todbot)
 Version: 0.1
 Status: Functional but WIP
+date: 2024-11-30
 
 tags:
   - bass

--- a/releases/30_cirpy_wavetable/info.yaml
+++ b/releases/30_cirpy_wavetable/info.yaml
@@ -5,6 +5,7 @@ Language: CircuitPython
 Creator: Tod Kurt (@todbot)
 Version: 0.1
 Status: Functional but WIP
+date: 2024-11-30
 
 tags:
   - wavetable

--- a/releases/31_esp/info.yaml
+++ b/releases/31_esp/info.yaml
@@ -5,6 +5,7 @@ Language: C++ (ComputerCard)
 Creator: Ben Regnier
 Version: 1.0
 Status: Released
+date: 2025-12-01
 
 tags:
   - external-signal-processor

--- a/releases/32_vink/info.yaml
+++ b/releases/32_vink/info.yaml
@@ -5,6 +5,7 @@ Language: C++ (ComputerCard)
 Creator: Ben Regnier
 Version: 1.1
 Status: Functional
+date: 2025-12-01
 
 tags:
   - delay

--- a/releases/33_drumdrum/info.yaml
+++ b/releases/33_drumdrum/info.yaml
@@ -6,6 +6,7 @@ Creator: Moses Hoyt
 Version: 1.2.0
 Status: Functional but WIP
 License: MIT
+date: 2026-05-05
 Editor: https://mohoyt.com/drumdrum.html
 
 tags:

--- a/releases/34_dual_quant/info.yaml
+++ b/releases/34_dual_quant/info.yaml
@@ -4,6 +4,7 @@ draft: false
 release: 34 / 1.0
 summary: Dual quantised granular pitch shifter with calibrated 1V/oct CV outputs
 description: Dual quantised granular pitch shifter with calibrated 1V/oct CV outputs
+date: 2026-06-14
 panel:
   controls:
     main:

--- a/releases/35_FreqShift/info.yaml
+++ b/releases/35_FreqShift/info.yaml
@@ -5,6 +5,7 @@ Language: C++ (ComputerCard)
 Creator: Ben Regnier
 Version: 1.1
 Status: Functional
+date: 2026-06-14
 
 tags:
   - frequency-shifter

--- a/releases/36_GradualProcess/info.yaml
+++ b/releases/36_GradualProcess/info.yaml
@@ -5,6 +5,7 @@ Language: C++ (ComputerCard)
 Creator: James Saunders
 Version: 1.0.0
 Status: Released
+date: 2026-07-04
 
 tags:
   - generative

--- a/releases/37_compulidean/info.yaml
+++ b/releases/37_compulidean/info.yaml
@@ -6,6 +6,7 @@ Creator: Tristan Rowley
 Version: (see source repo)
 Status: Functional, but WIP
 Repository: https://github.com/doctea/compulidian
+date: 2025-04-27
 
 summary: |
   Drum-machine card built around Euclidean pattern generation and sample playback.

--- a/releases/38_od/info.yaml
+++ b/releases/38_od/info.yaml
@@ -6,6 +6,7 @@ Creator: M. John Mills
 Version: 1.0
 Status: Released
 License: MIT
+date: 2025-01-26
 Repository: https://github.com/MJLMills/mtmws_od
 
 summary: |

--- a/releases/39_knots/info.yaml
+++ b/releases/39_knots/info.yaml
@@ -5,6 +5,7 @@ Language: C++ (RPi Pico SDK / ComputerCard)
 Creator: Jeff Fletcher
 Version: 0.2
 Status: Released
+date: 2026-03-22
 
 summary: |
   Six-engine oscillator card with Normal/Alt output modes, MIDI input, and clock/gate utilities.

--- a/releases/41_blackbird/info.yaml
+++ b/releases/41_blackbird/info.yaml
@@ -6,6 +6,7 @@ Creator: Dune Desormeaux
 Version: 1.1
 Status: Released
 License: GPLv3 or later
+date: 2025-11-10
 Editor: https://dessertplanet.github.io/web-druid/
 demo-link: https://youtu.be/V9HAspnpEWU
 

--- a/releases/42_backyard_rain/info.yaml
+++ b/releases/42_backyard_rain/info.yaml
@@ -6,6 +6,7 @@ Creator: Brian Dorsey
 Version: (see source repo)
 Status: Released
 Repository: https://codeberg.org/briandorsey/mtmws_cards
+date: 2025-01-20
 
 summary: |
   Ambient backyard rain playback card with user-controlled intensity.

--- a/releases/44_Birds/info.yaml
+++ b/releases/44_Birds/info.yaml
@@ -5,6 +5,7 @@ Language: C++ (Pico SDK / ComputerCard)
 Creator: Tom Whitwell
 Version: 0.5.0
 Status: Beta
+date: 2026-05-25
 
 summary: |
   Two interacting birds are generated from a Turing-style looped random sequencer.

--- a/releases/47_NZT/info.yaml
+++ b/releases/47_NZT/info.yaml
@@ -6,6 +6,7 @@ Creator: "@kjnilsson"
 Version: 1.0.0
 Status: Released
 Repository: https://github.com/kjnilsson/ws
+date: 2025-10-02
 
 summary: |
   Grain-noise generator and noise utility card with density control, seed modulation, CV utilities,

--- a/releases/48_two_tracks/info.yaml
+++ b/releases/48_two_tracks/info.yaml
@@ -6,6 +6,7 @@ Creator: Joep Vermaat
 Version: 1.1
 Status: Released
 License: MIT
+date: 2026-07-11
 Repository: https://codeberg.org/johantv/two-tracks
 
 tags:

--- a/releases/50_flux/info.yaml
+++ b/releases/50_flux/info.yaml
@@ -6,6 +6,7 @@ Creator: Vincent Maurer
 Version: 1.0
 Status: Released
 Editor: https://vincentmaurer.de/flux/flux_manager.html
+date: 2026-06-14
 
 tags:
   - multi-fx

--- a/releases/51_grains/info.yaml
+++ b/releases/51_grains/info.yaml
@@ -6,6 +6,7 @@ Creator: Vincent Maurer
 Version: 1.0
 Status: Released
 Editor: https://vincentmaurer.de/grains/grains_manager.html
+date: 2026-06-14
 
 tags:
   - granular

--- a/releases/53_glitter/info.yaml
+++ b/releases/53_glitter/info.yaml
@@ -6,6 +6,7 @@ Creator: Steve Jones
 Version: 0.1.2-beta
 Status: Beta
 License: MIT
+date: 2025-04-04
 Repository: https://github.com/sdrjones/mtws/tree/main/53_glitter
 
 tags:

--- a/releases/54_Tapegrade/info.yaml
+++ b/releases/54_Tapegrade/info.yaml
@@ -2,6 +2,7 @@ id: Tapegrade
 title: Tapegrade
 draft: false
 release: 54 / 0.8.0
+date: 2026-06-14
 summary: >-
   Mono-input stereo cassette warble processor with wow, flutter, hiss, crackle, and tape
   wear morphing.

--- a/releases/55_fifths/info.yaml
+++ b/releases/55_fifths/info.yaml
@@ -6,6 +6,7 @@ Creator: Dune Desormeaux
 Version: 1.1
 Status: Released
 demo-link: https://youtu.be/xdUCDX7FmOA
+date: 2025-05-24
 
 tags:
   - quantizer

--- a/releases/56_Krell/info.yaml
+++ b/releases/56_Krell/info.yaml
@@ -5,6 +5,7 @@ Language: Blackbird Lua
 Creator: Benjamin Reily
 Version: 1.0
 Status: Mostly complete
+date: 2026-02-26
 
 tags:
   - generative

--- a/releases/57_glitch/info.yaml
+++ b/releases/57_glitch/info.yaml
@@ -6,6 +6,7 @@ Creator: Andy Jenkinson (uglifruit)
 Version: 1.4.0
 Status: Released
 License: MIT
+date: 2026-05-20
 Repository: https://github.com/uglifruit/Workshop_Computer/tree/main/Demonstrations%2BHelloWorlds/PicoSDK/ComputerCard/examples/glitch
 
 tags:

--- a/releases/58_LoChoVibes/info.yaml
+++ b/releases/58_LoChoVibes/info.yaml
@@ -2,6 +2,7 @@ id: 58_LoChoVibes
 title: LoCho Vibes
 draft: false
 release: 58 / 0.1.0
+date: 2026-06-14
 summary: >-
   Stereo chorus and vibrato effect featuring triangle, sine, and slow drift LFO modes,
   modulation-based delay movement, and tape-style saturation.

--- a/releases/59_BitPhase/info.yaml
+++ b/releases/59_BitPhase/info.yaml
@@ -4,6 +4,7 @@ draft: false
 release: 59 / 0.1.0
 summary: Resonant 4-stage phaser with wide modulation sweeps, tremolo blending, and Burst-mode degradation
 description: Resonant 4-stage phaser for the Workshop Computer with deep notch filtering, wide modulation sweeps, controllable resonance, tremolo blending, and digital Burst-mode degradation.
+date: 2026-06-24
 
 panel:
   controls:

--- a/releases/60_markov/info.yaml
+++ b/releases/60_markov/info.yaml
@@ -5,6 +5,7 @@ Language: C++ (Pico SDK)
 Creator: Andy Jenkinson (uglifruit)
 Version: 1.0.0
 Status: Released
+date: 2026-05-30
 
 summary: |
   Dual Markov-chain generator with melody on voice A and rhythm/percussion on voice B.

--- a/releases/64_voices_of_sid/info.yaml
+++ b/releases/64_voices_of_sid/info.yaml
@@ -6,6 +6,7 @@ Creator: Joep Vermaat
 Version: 1.1
 Status: Released
 License: MIT
+date: 2026-06-07
 Repository: https://codeberg.org/johantv/voices-of-sid
 
 tags:

--- a/releases/66_stretchcore/info.yaml
+++ b/releases/66_stretchcore/info.yaml
@@ -6,6 +6,7 @@ Creator: Infinite Digits
 Version: 1.0
 Status: Ready%
 Editor: https://infinitedigits.co/stretchcore/
+date: 2026-06-02
 
 summary: |
   Mono sample-loop player with browser-loaded sample bank, tempo control, timestretch,

--- a/releases/67_Fragments/info.yaml
+++ b/releases/67_Fragments/info.yaml
@@ -6,3 +6,4 @@ Version: 1.0
 Status: Released
 Editor: web
 web-entry: fragments_librarian.html
+date: 2026-07-09

--- a/releases/69_trace/info.yaml
+++ b/releases/69_trace/info.yaml
@@ -6,6 +6,7 @@ Creator: Ruiyang Wang
 Version: 0.1
 Status: Functional but WIP
 Repository: https://github.com/indiepaleale/Trace-Workshop-Computer
+date: 2026-01-18
 
 summary: |
   Oscillograph-focused dual-output oscillator bank for X/Y scope visuals. Main controls

--- a/releases/71_degenerator/info.yaml
+++ b/releases/71_degenerator/info.yaml
@@ -6,6 +6,7 @@ Creator: Joep Vermaat
 Version: 1.3
 Status: Released
 License: MIT
+date: 2026-05-08
 Editor: https://degenerator-web.netlify.app/
 Repository: https://codeberg.org/johantv/Degenerator
 

--- a/releases/72_motorik/info.yaml
+++ b/releases/72_motorik/info.yaml
@@ -6,6 +6,7 @@ Creator: Joep Vermaat
 Version: 1.0
 Status: Released
 License: MIT
+date: 2026-05-17
 Repository: https://codeberg.org/johantv/motorik
 
 summary: |

--- a/releases/74_Wild_Pebble/info.yaml
+++ b/releases/74_Wild_Pebble/info.yaml
@@ -4,6 +4,7 @@ draft: false
 release: 74 / 1.0
 summary: MIDI-clockable generative rhythm and melody organism inspired by Pet Rock
 description: MIDI-clockable generative rhythm and melody organism inspired by Pet Rock
+date: 2026-06-14
 panel:
   controls:
     main:

--- a/releases/76_hot_fuzz/info.yaml
+++ b/releases/76_hot_fuzz/info.yaml
@@ -6,6 +6,7 @@ Creator: Joep Vermaat
 Version: 1.0
 Status: Released
 License: MIT
+date: 2026-07-04
 Repository: https://codeberg.org/johantv/hot-fuzz
 
 tags:

--- a/releases/77_Placeholder/info.yaml
+++ b/releases/77_Placeholder/info.yaml
@@ -5,3 +5,4 @@ Language: None
 Creator: None
 Version: 0.0
 Status: None
+date: 2024-11-30

--- a/releases/78_Talker/info.yaml
+++ b/releases/78_Talker/info.yaml
@@ -6,6 +6,7 @@ Creator: Chris Johnson
 Version: 0.1
 Status: Proof of concept
 License: GPL-3.0
+date: 2024-11-30
 
 tags:
   - speech

--- a/releases/81_West_Coast_LPG/info.yaml
+++ b/releases/81_West_Coast_LPG/info.yaml
@@ -4,3 +4,4 @@ Language: "C++ (ComputerCard)"
 Creator: "Jason Moore"
 Version: "0.1"
 Status: "Working"
+date: 2026-06-08

--- a/releases/82_Computer_Grids/info.yaml
+++ b/releases/82_Computer_Grids/info.yaml
@@ -6,6 +6,7 @@ Creator: Phil Miller
 Version: 0.1.0
 Status: Released
 License: GPL-3.0-or-later
+date: 2026-04-01
 contact:
   website: https://github.com/philmillman
   social:

--- a/releases/83_Origami/info.yaml
+++ b/releases/83_Origami/info.yaml
@@ -4,3 +4,4 @@ Language: "C++ (ComputerCard)"
 Creator: "Jason Moore"
 Version: "0.1"
 Status: "Working"
+date: 2026-06-30

--- a/releases/84_CosmikC1zzl3/info.yaml
+++ b/releases/84_CosmikC1zzl3/info.yaml
@@ -2,6 +2,7 @@ id: 84_CosmikC1zzl3
 title: Cosmik C1ZZL3
 draft: false
 release: 84 / 1.1
+date: 2026-06-24
 summary: >-
   Stable phase-distortion synthesiser and Turing machine firmware with Web MIDI
   envelope readback, PD, detune, eight waveform families, hosted CZ patch

--- a/releases/86_tesserae/info.yaml
+++ b/releases/86_tesserae/info.yaml
@@ -6,6 +6,7 @@ Creator: Joep Vermaat
 Version: 1.0
 Status: released
 License: MIT
+date: 2026-05-08
 Repository: https://codeberg.org/johantv/Tesserae
 
 tags:

--- a/releases/87_fr330hfr33/info.yaml
+++ b/releases/87_fr330hfr33/info.yaml
@@ -3,6 +3,7 @@ title: Fr330hfr33
 release: 87 / 0.9.3
 summary: Performance-focused acid voice with diode filtering, distortion, MIDI, and a persistent sequencer
 description: Hardware-tested acid bass synthesiser with selectable saw or square oscillator, switchable 18 or 24 dB diode-style filtering, accent and glide, distortion, USB MIDI device/host operation, and a persistent editable sequencer.
+date: 2026-06-21
 panel:
   controls:
     main:

--- a/releases/88_Blank/info.yaml
+++ b/releases/88_Blank/info.yaml
@@ -5,3 +5,4 @@ Language: None
 Creator: Tom Whitwell
 Version: 0
 Status: None
+date: 2024-11-30

--- a/releases/90_Pantograph/info.yaml
+++ b/releases/90_Pantograph/info.yaml
@@ -5,6 +5,7 @@ Language: Pico SDK
 Creator: Kenny Shen
 Version: 1.1
 Status: Ready
+date: 2026-06-29
 
 tags:
   - cv

--- a/releases/91_chorgan/info.yaml
+++ b/releases/91_chorgan/info.yaml
@@ -4,6 +4,7 @@ Language: C++ (Pico SDK / ComputerCard)
 Creator: Andy Jenkinson (uglifruit)
 Version: 1.1.0
 Status: released
+date: 2026-06-21
 
 tags:
   - synthesizer

--- a/releases/93_Turing_Matrix/info.yaml
+++ b/releases/93_Turing_Matrix/info.yaml
@@ -4,6 +4,7 @@ draft: false
 release: 93 / 0.1.0-beta
 summary: Turing Machine sequencer with a switchable mixer layer inspired by the Music Thing Modular Turing Machine and Vactrol Mix combination
 description: Turing Machine sequencer with a switchable mixer layer inspired by the Music Thing Modular Turing Machine and Vactrol Mix combination
+date: 2026-06-26
 panel:
   controls:
     main:

--- a/releases/95_offair2/info.yaml
+++ b/releases/95_offair2/info.yaml
@@ -5,6 +5,7 @@ Creator: Andy Jenkinson (uglifruit)
 Version: 1.0.1
 Status: released
 License: CC BY-SA 4.0
+date: 2026-06-27
 Repository: https://github.com/uglifruit/Workshop_Computer
 
 tags:

--- a/releases/96_cathode/info.yaml
+++ b/releases/96_cathode/info.yaml
@@ -6,6 +6,7 @@ Creator: Andy Jenkinson (uglifruit)
 Version: 1.2.0
 Status: Released
 License: MIT
+date: 2026-06-30
 Repository: https://github.com/TomWhitwell/Workshop_Computer/tree/main/releases/96_cathode
 
 tags:

--- a/releases/97_alloy/info.yaml
+++ b/releases/97_alloy/info.yaml
@@ -6,6 +6,7 @@ Creator: Eric Gao
 Version: 0.2.0
 Status: Beta
 License: MIT
+date: 2026-07-08
 Repository: https://github.com/Ericxgao/Workshop_Computer/tree/eric/warps-port/releases/97_alloy
 
 tags:

--- a/releases/98_duo_midi/info.yaml
+++ b/releases/98_duo_midi/info.yaml
@@ -5,6 +5,7 @@ Language: Lua / Blackbird
 Creator: Dune Desormeaux
 Version: 0.1
 Status: Released
+date: 2026-01-09
 
 tags:
   - midi

--- a/releases/99_toolbox/info.yaml
+++ b/releases/99_toolbox/info.yaml
@@ -6,6 +6,7 @@ Creator: divmod
 Version: 0.1.1
 Status: Released
 Repository: https://github.com/divmod-audio/toolbox
+date: 2025-10-01
 
 tags:
   - utility

--- a/scripts/backfill_dates.py
+++ b/scripts/backfill_dates.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Backfill a `date:` field into each release card's info.yaml.
+
+Uses Phil's git-blame pattern: run `git blame` on the card's own info.yaml and
+take the OLDEST surviving per-line author date. Bulk edits rewrite most lines to
+a recent date, but original lines keep their real dates, so the minimum blame
+date is a bulk-edit-resistant estimate of when the card's metadata first existed.
+
+This is a single, uniform method that works for every card that has an
+info.yaml, including cards with no .uf2 firmware (Python / external-link /
+placeholder stubs).
+
+Dry-run by default. Pass --apply to write changes. Existing `date:` values are
+preserved and those cards are skipped.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+RELEASES = os.path.join(ROOT, "releases")
+
+DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
+# Existing top-level date key (schema treats hyphens/spaces as equivalent and
+# maps `releasedate` -> date).
+HAS_DATE_RE = re.compile(r"(?i)^(date|release[\s-]?date)\s*:")
+# A top-level key line (starts at column 0, no leading whitespace).
+TOP_KEY_RE = re.compile(r"^([A-Za-z][\w -]*?)\s*:(.*)$")
+
+
+def oldest_blame_date(rel_info_path):
+    """Return the oldest author date (YYYY-MM-DD) across all lines of a file."""
+    try:
+        out = subprocess.run(
+            ["git", "blame", "--date=short", "-l", rel_info_path],
+            cwd=ROOT, check=True, capture_output=True, text=True,
+        ).stdout
+    except subprocess.CalledProcessError as e:
+        print(f"  ! git blame failed for {rel_info_path}: {e.stderr.strip()}",
+              file=sys.stderr)
+        return None
+    dates = DATE_RE.findall(out)
+    return min(dates) if dates else None
+
+
+def insertion_index(lines):
+    """Choose where to insert the date line.
+
+    Only ever anchors on a TOP-LEVEL (column 0), single-line scalar key so we
+    never split a nested block or a folded/literal (`>`/`|`) block scalar.
+    Prefers just after a top-level `License:`; otherwise after the last simple
+    top-level scalar in the opening core block (stopping at the first blank line
+    or the first top-level block opener such as `panel:`/`tags:`)."""
+    last_scalar = None
+    for i, line in enumerate(lines):
+        stripped = line.rstrip("\n")
+        if stripped.strip() == "" or stripped.lstrip().startswith("#"):
+            if last_scalar is not None:
+                break  # blank/comment ends the opening core block
+            continue
+        m = TOP_KEY_RE.match(stripped)
+        if not m:
+            # Indented line (block content) — end of the top-level core block.
+            if last_scalar is not None:
+                break
+            continue
+        key, value = m.group(1), m.group(2).strip()
+        # Block openers: empty value (mapping/sequence) or folded/literal scalar.
+        if value == "" or value.startswith(">") or value.startswith("|"):
+            break
+        last_scalar = i
+        if key.strip().lower() == "license":
+            return i + 1
+    if last_scalar is not None:
+        return last_scalar + 1
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--apply", action="store_true",
+                    help="write changes (default: dry run)")
+    args = ap.parse_args()
+
+    folders = sorted(
+        d for d in os.listdir(RELEASES)
+        if os.path.isfile(os.path.join(RELEASES, d, "info.yaml"))
+    )
+
+    planned = 0
+    skipped = 0
+    for folder in folders:
+        info_path = os.path.join(RELEASES, folder, "info.yaml")
+        rel = os.path.relpath(info_path, ROOT)
+        with open(info_path, "r", encoding="utf-8") as f:
+            text = f.read()
+        lines = text.splitlines(keepends=True)
+
+        if any(HAS_DATE_RE.match(l) for l in lines):
+            existing = next(l.strip() for l in lines if HAS_DATE_RE.match(l))
+            print(f"skip  {folder:<24} (has {existing})")
+            skipped += 1
+            continue
+
+        date = oldest_blame_date(rel)
+        if not date:
+            print(f"skip  {folder:<24} (no blame date)")
+            skipped += 1
+            continue
+
+        idx = insertion_index(lines)
+        # Ensure the line we insert after ends with a newline.
+        if idx > 0 and not lines[idx - 1].endswith("\n"):
+            lines[idx - 1] += "\n"
+        date_line = f"date: {date}\n"
+        print(f"add   {folder:<24} date: {date}")
+        planned += 1
+
+        if args.apply:
+            lines.insert(idx, date_line)
+            with open(info_path, "w", encoding="utf-8") as f:
+                f.write("".join(lines))
+
+    print(f"\n{'APPLIED' if args.apply else 'DRY RUN'}: "
+          f"{planned} to add, {skipped} skipped, {len(folders)} total")
+    if not args.apply and planned:
+        print("Re-run with --apply to write these changes.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request adds release dates to the `info.yaml` files for all projects in the `releases` directory. Each release now includes a `date` field, improving metadata consistency and making it easier to track release timelines across the repository.

Also added a script to /scripts that can be used in the future for similar bulk updates.

No other changes were made.