### PR TITLE
schema update: Description -> short-description

### DIFF
--- a/documentation/info.yaml.md
+++ b/documentation/info.yaml.md
@@ -9,7 +9,8 @@ Keys are case-insensitive. Hyphens and spaces in key names are equivalent (`audi
 ```yaml
 draft: true
 Name: Card Display Name
-Description: One-line summary of what the card does
+short-description: One-line catalog tagline
+summary: Longer operator overview of what the card does and how it is used
 Language: C++ (Pico SDK)
 Creator: Your Name
 Version: 1.0
@@ -23,8 +24,8 @@ License: MIT
 |-------|----------|------|-------------|
 | `draft` | no | boolean | When `true`, structured metadata in this file is still under author review. Set to `false` when `Name`, `contact`, `License`, `panel`, and related fields are confirmed. Not rendered on detail pages yet; parsed for tooling and future site UI. |
 | `Name` | yes | string | Display title on the site index and detail page (see sitegen). |
-| `Description` | yes | string | Short blurb shown on the index and detail aside. |
-| `summary` | no | string | Short operator summary shown in the card header. Falls back to `Description` when absent. |
+| `short-description` | yes | string | Concise catalog tagline shown on index tiles, discovery shelves, and archive rows. |
+| `summary` | yes | string | Longer operator overview shown beneath the title on the card detail page. |
 | `Language` | yes | string | Implementation language or stack (e.g. `C++ (Pico SDK)`, `Lua / Blackbird`). |
 | `Creator` | yes | string | Author or maintainer name. |
 | `Version` | yes | string | Semantic or project version string. |
@@ -108,7 +109,6 @@ uf2:
 |-------|----------|------|-------------|
 | `demo-link` | no | string (URL) | Optional YouTube URL (`watch`, `youtu.be`, `/shorts/`, `/embed/`). Rendered as a demo-video thumbnail on the detail page that plays inline when clicked. README YouTube links also get inline embeds. |
 | `audio-sample` | no | string or list | Demo audio. Accepts a single value or a list. Each value may be: a **repo-relative file** (e.g. `samples/demo.wav`, resolved to a raw URL and rendered with an `<audio>` player); a **SoundCloud** track/set URL (embedded as a player, derived from the URL — no API key); a **Bandcamp** *EmbeddedPlayer* URL (the iframe `src` from Bandcamp's Share → Embed dialog); or any other URL (shown as a link). You may also paste a whole embed `<iframe>` snippet (we extract the player `src` + height), but you must single-quote it in YAML. List items may also be `{ url, title }` objects (`title` shows above the player). |
-
 ```yaml
 # single file
 audio-sample: samples/demo.wav
@@ -148,7 +148,7 @@ readme: |
   Patch an audio signal to **Audio In 1**, then use Main to set the amount.
 ```
 
-`readme` replaces the former `manual` field. Existing authored `manual` content should be migrated to `readme`; `summary` remains the short player-facing header text.
+`readme` replaces the former `manual` field. Existing authored `manual` content should be migrated to `readme`; `summary` remains the operator overview shown in the card detail header.
 
 See [`releases/82_Computer_Grids/info.yaml`](../releases/82_Computer_Grids/info.yaml) for a full structured example.
 
@@ -211,9 +211,9 @@ controls:
   knobs: ...
 ```
 
-**Preserve** existing `Description`, `Language`, `Creator`, `Version`, `Status`, `License`, `Editor`, and `Repository` values unless deployment rules require a change.
+**Preserve** existing `short-description`, `summary`, `Language`, `Creator`, `Version`, `Status`, `License`, `Editor`, and `Repository` values unless deployment rules require a change.
 
-Every card must include **`Name`** — the site index and detail page title come from this field (not `Description`). Legacy `Title` is still read as a fallback if `Name` is absent.
+Every card must include **`Name`** — the site index and detail page title come from this field. Legacy `Title` is still read as a fallback if `Name` is absent.
 
 ## Automation
 

--- a/releases/00_Simple_MIDI/info.yaml
+++ b/releases/00_Simple_MIDI/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Simple MIDI
-Description: Takes USB midi, sends it to pulse and CV outputs, also sends knob positions and CV inputs back to the computer as CC values.
+short-description: Takes USB midi, sends it to pulse and CV outputs, also sends knob positions and CV inputs back to the computer as CC values.
 Language: Arduino-Pico
 Creator: Tom Whitwell
 Version: 0.6.6

--- a/releases/02_comingsoon/info.yaml
+++ b/releases/02_comingsoon/info.yaml
@@ -1,6 +1,7 @@
 draft: true
 Name: Coming Soon
-Description: Reserved for upcoming project
+short-description: Reserved for upcoming project
+summary: Reserved for upcoming project
 Language: None
 Creator: None
 Version: 0.0

--- a/releases/03_Turing_Machine/info.yaml
+++ b/releases/03_Turing_Machine/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Turing Machine
-Description: Turing Machine with tap tempo clock, 2 x pulse outputs, 4 x CV outputs
+short-description: Turing Machine with tap tempo clock, 2 x pulse outputs, 4 x CV outputs
 Language: C++ (ComputerCard)
 Creator: Tom Whitwell
 Version: 1.5.3

--- a/releases/04_BYO_Benjolin/info.yaml
+++ b/releases/04_BYO_Benjolin/info.yaml
@@ -1,6 +1,6 @@
 draft: false
 Name: BYO Benjolin
-Description: Rungler, Chaotic VCO, Noise Source, Turing Machine, Quantizer
+short-description: Rungler, Chaotic VCO, Noise Source, Turing Machine, Quantizer
 Language: Pico SDK
 Creator: Dune Desormeaux
 Version: 1.1

--- a/releases/05_chord_blimey/info.yaml
+++ b/releases/05_chord_blimey/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Chord Blimey!
-Description: Generates CV/Pulse arpeggios
+short-description: Generates CV/Pulse arpeggios
 Language: C (RPi Pico SDK)
 Creator: Tom Waters
 Version: 0.9

--- a/releases/06_usb_audio/info.yaml
+++ b/releases/06_usb_audio/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: USB Audio & MIDI
-Description: 6-Channel USB Audio & MIDI firmware with CV/Gate support
+short-description: 6-Channel USB Audio & MIDI firmware with CV/Gate support
 Language: C++ (RPi Pico SDK)
 Creator: Vincent Maurer (vincentmaurer.de)
 Version: 1.0

--- a/releases/07_bumpers/info.yaml
+++ b/releases/07_bumpers/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Bumpers
-Description: "'Bouncing ball' style delay and trigger generators"
+short-description: "'Bouncing ball' style delay and trigger generators"
 Language: C++ (ComputerCard)
 Creator: Chris Johnson
 Version: 1.0

--- a/releases/08_bytebeat/info.yaml
+++ b/releases/08_bytebeat/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Bytebeat
-Description: Generates and mangles bytebeats
+short-description: Generates and mangles bytebeats
 Language: C++/Arduino-Pico
 Creator: Matt Kuebrich
 Version: 0.1

--- a/releases/09_DivCom/info.yaml
+++ b/releases/09_DivCom/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: DivCom
-Description: Comparator and VC clock divider, inspired by Serge NCOM
+short-description: Comparator and VC clock divider, inspired by Serge NCOM
 Language: C++ (RPi Pico SDK) compat. cmake.
 Creator: divmod
 Version: 0.1

--- a/releases/10_twists/info.yaml
+++ b/releases/10_twists/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Twists
-Description: A port of Mutable Instruments Braids with a web editor
+short-description: A port of Mutable Instruments Braids with a web editor
 Language: C (RPi Pico SDK)
 Creator: Random Works
 Version: 0.1

--- a/releases/11_goldfish/info.yaml
+++ b/releases/11_goldfish/info.yaml
@@ -1,6 +1,6 @@
 draft: false
 Name: Goldfish
-Description: Weird delay/looper for audio and CV
+short-description: Weird delay/looper for audio and CV
 Language: Pico SDK
 Creator: Dune Desormeaux
 Version: 2.0

--- a/releases/12_am_coupler/info.yaml
+++ b/releases/12_am_coupler/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: AM Coupler
-Description: AM radio transmitter / coupler
+short-description: AM radio transmitter / coupler
 Language: C++ (ComputerCard)
 Creator: Chris Johnson
 Version: 1.0

--- a/releases/13_noisebox/info.yaml
+++ b/releases/13_noisebox/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Noisebox
-Description: 13-algorithm noise synth with CV modulation, sample-and-hold, and crusher mode
+short-description: 13-algorithm noise synth with CV modulation, sample-and-hold, and crusher mode
 Language: C++ (ComputerCard)
 Creator: Eric Gao
 Version: 1.0

--- a/releases/14_cvmod/info.yaml
+++ b/releases/14_cvmod/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: CVMod
-Description: Quad CV delay inspired by Make Noise Multimod
+short-description: Quad CV delay inspired by Make Noise Multimod
 Language: C++ (ComputerCard)
 Creator: Chris Johnson
 Version: 1.0

--- a/releases/15_MLRws/info.yaml
+++ b/releases/15_MLRws/info.yaml
@@ -1,6 +1,6 @@
 draft: false
 Name: MLRws
-Description: "A remix of monome's classic MLR sample cutting platform (grid controller encouraged but optional). Diagrams here are for Gridless mode."
+short-description: "A remix of monome's classic MLR sample cutting platform (grid controller encouraged but optional). Diagrams here are for Gridless mode."
 Language: Pico SDK
 Creator: Dune Desormeaux
 Version: 1.1.5

--- a/releases/16_the_bells/info.yaml
+++ b/releases/16_the_bells/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: The Bells
-Description: Bellringing methods sequencer — 12 change-ringing methods with tempo and jitter, quantised to six scales
+short-description: Bellringing methods sequencer — 12 change-ringing methods with tempo and jitter, quantised to six scales
 Language: C++ (ComputerCard)
 Creator: James Saunders
 Version: 1.0.0

--- a/releases/17_COMET/info.yaml
+++ b/releases/17_COMET/info.yaml
@@ -1,6 +1,7 @@
 draft: False
 Name: COMET
-Description: Clocked lo-fi reverb and delay
+short-description: Clocked lo-fi reverb and delay
+summary: Clocked lo-fi reverb and delay
 Language: C++ (Pico SDK, ComputerCard)
 Creator: EME
 Version: 1.0

--- a/releases/18_chord_organ/info.yaml
+++ b/releases/18_chord_organ/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Chord Organ-ish
-Description: Chord Organ-ish - 16 chords, 8 voices, 1V/oct root. Inspired by Music Thing Chord Organ.
+short-description: Chord Organ-ish - 16 chords, 8 voices, 1V/oct root. Inspired by Music Thing Chord Organ.
 Language: Pico SDK (C++), ComputerCard
 Creator: jkeyworth
 Version: 0.1

--- a/releases/19_CA_Sequencer/info.yaml
+++ b/releases/19_CA_Sequencer/info.yaml
@@ -1,4 +1,5 @@
-Description: 16-cell gate and quantized CV melody generator inspired by NLC Cellular Automata, using CA rules 90 & 150 on a 4x4 grid
+short-description: 16-cell gate and quantized CV melody generator inspired by NLC Cellular Automata, using CA rules 90 & 150 on a 4x4 grid
+summary: 16-cell gate and quantized CV melody generator inspired by NLC Cellular Automata, using CA rules 90 & 150 on a 4x4 grid
 Name: Cellular Automata Sequencer
 Language: C++ (Pico SDK)
 Creator: Ainews

--- a/releases/20_reverb/info.yaml
+++ b/releases/20_reverb/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Reverb+
-Description: Reverb effect, plus pulse/CV generators and MIDI-to-CV, configurable using web interface.
+short-description: Reverb effect, plus pulse/CV generators and MIDI-to-CV, configurable using web interface.
 Language: C (RPi Pico SDK)
 Creator: Chris Johnson
 Version: 1.5

--- a/releases/21_resonator/info.yaml
+++ b/releases/21_resonator/info.yaml
@@ -1,4 +1,4 @@
-Description: Karplus-Strong sympathetic resonator for droning and plucked textures, with chord & tanpura tunings, arpeggiator, pitch tracking and web-configurable CV/pulse outputs.
+short-description: Karplus-Strong sympathetic resonator for droning and plucked textures, with chord & tanpura tunings, arpeggiator, pitch tracking and web-configurable CV/pulse outputs.
 draft: true
 Name: Resonator
 Language: C++ (ComputerCard)

--- a/releases/22_sheep/info.yaml
+++ b/releases/22_sheep/info.yaml
@@ -1,6 +1,6 @@
 draft: false
 Name: Sheep
-Description: A time-stretching and pitch-shifting granular processor and digital degradation playground with 2 fidelity options.
+short-description: A time-stretching and pitch-shifting granular processor and digital degradation playground with 2 fidelity options.
 Language: Pico SDK
 Creator: Dune Desormeaux
 Version: 1.2

--- a/releases/23_SlowMod/info.yaml
+++ b/releases/23_SlowMod/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: SlowMod
-Description: Chaotic quad-LFO with VCAs
+short-description: Chaotic quad-LFO with VCAs
 Language: C++ (RPi Pico SDK) compat. w/ cmake and Arduino IDE.
 Creator: divmod
 Version: 0.1

--- a/releases/24_crafted_volts/info.yaml
+++ b/releases/24_crafted_volts/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Crafted Volts
-Description: Manually set control voltages (CV) with the input knobs and switch. It also attenuverts (attenuates and inverts) incoming voltages.
+short-description: Manually set control voltages (CV) with the input knobs and switch. It also attenuverts (attenuates and inverts) incoming voltages.
 Language: Rust (Embassy framework)
 Creator: Brian Dorsey
 Version: (see source repo)

--- a/releases/25_utility_pair/info.yaml
+++ b/releases/25_utility_pair/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Utility Pair
-Description: 25 small utilities, which can be combined in pairs
+short-description: 25 small utilities, which can be combined in pairs
 Language: C++ (ComputerCard)
 Creator: Chris Johnson
 Version: 1.0

--- a/releases/26_clockwork/info.yaml
+++ b/releases/26_clockwork/info.yaml
@@ -10,7 +10,7 @@ contact:
   website: https://vincentmaurer.de
 summary: >-
   6-channel polyrhythmic clock, gate, and LFO/envelope generator inspired by Pamela's Workout.
-description: >-
+short-description: >-
   6-channel polyrhythmic clock, gate, and LFO/envelope generator inspired by Pamela's Workout.
 panel:
   controls:
@@ -130,7 +130,7 @@ metadata:
   version: 1.0.0
   status: Released
   license: MIT
-manual: |
+readme: |
     Clockwork is a 6-channel polyrhythmic timing and modulation generator inspired by Pamela's Workout. It turns the Workshop Computer into a central clock, gate sequencer, and LFO generator.
 
     *   [Clockwork Tutorial Video](https://youtu.be/Pc0wPOAVZmw)

--- a/releases/27_Siren/info.yaml
+++ b/releases/27_Siren/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Siren
-Description: Multi-algorithm drone oscillator. Inspired by the Forge TME Vhikk X.
+short-description: Multi-algorithm drone oscillator. Inspired by the Forge TME Vhikk X.
 Language: C++ (ComputerCard / Pico SDK)
 Creator: Moses Hoyt
 Version: 0.2

--- a/releases/28_eighties_bass/info.yaml
+++ b/releases/28_eighties_bass/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Eighties Bass
-Description: Bass-oriented complete monosynth voice consisting of five detuned saw wave oscillators with mixable white noise and adjustable resonant filter.
+short-description: Bass-oriented complete monosynth voice consisting of five detuned saw wave oscillators with mixable white noise and adjustable resonant filter.
 Language: Arduino (arduino-pico) with Mozzi 2
 Creator: Tod Kurt (@todbot)
 Version: 0.1

--- a/releases/29_XHT/info.yaml
+++ b/releases/29_XHT/info.yaml
@@ -1,6 +1,6 @@
 draft: false
 Name: XHT Card
-Description: A playable deep-note-inspired stereo chord swarm with manual scrubbing, one-shot movement, delay, reverb, CV, pulse, and optional MIDI control.
+short-description: A playable deep-note-inspired stereo chord swarm with manual scrubbing, one-shot movement, delay, reverb, CV, pulse, and optional MIDI control.
 Language: C++ (Pico SDK)
 Creator: Adrian Vos
 Version: 0.1.0

--- a/releases/303_acid/info.yaml
+++ b/releases/303_acid/info.yaml
@@ -1,6 +1,6 @@
 draft: false
 Name: Acid
-Description: A 303-style step sequencer
+short-description: A 303-style step sequencer
 Language: C++ (ComputerCard)
 Creator: Samuel Smith
 Version: 1.0.0

--- a/releases/30_cirpy_wavetable/info.yaml
+++ b/releases/30_cirpy_wavetable/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Cirpy Wavetable
-Description: Wavetable oscillator that using wavetables from Plaits, Braids, and Microwave,
+short-description: Wavetable oscillator that using wavetables from Plaits, Braids, and Microwave,
 Language: CircuitPython
 Creator: Tod Kurt (@todbot)
 Version: 0.1

--- a/releases/31_esp/info.yaml
+++ b/releases/31_esp/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: ESP
-Description: A MS-20-style External Signal Processor that includes a preamp, bandpass filter, envelope follower, gate, and 1v/oct pitch outs.
+short-description: A MS-20-style External Signal Processor that includes a preamp, bandpass filter, envelope follower, gate, and 1v/oct pitch outs.
 Language: C++ (ComputerCard)
 Creator: Ben Regnier
 Version: 1.0

--- a/releases/32_vink/info.yaml
+++ b/releases/32_vink/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Vink
-Description: Dual delay loops with sigmoid saturation for Jaap Vink / Roland Kayn style feedback patching
+short-description: Dual delay loops with sigmoid saturation for Jaap Vink / Roland Kayn style feedback patching
 Language: C++ (ComputerCard)
 Creator: Ben Regnier
 Version: 1.1

--- a/releases/33_drumdrum/info.yaml
+++ b/releases/33_drumdrum/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: drumdrum
-Description: DFAM-style 8-step sequencer
+short-description: DFAM-style 8-step sequencer
 Language: C++ (ComputerCard / Pico SDK)
 Creator: Moses Hoyt
 Version: 1.2.0

--- a/releases/34_dual_quant/info.yaml
+++ b/releases/34_dual_quant/info.yaml
@@ -3,7 +3,7 @@ title: DualQuant
 draft: false
 release: 34 / 1.0
 summary: Dual quantised granular pitch shifter with calibrated 1V/oct CV outputs
-description: Dual quantised granular pitch shifter with calibrated 1V/oct CV outputs
+short-description: Dual quantised granular pitch shifter with calibrated 1V/oct CV outputs
 date: 2026-06-14
 panel:
   controls:

--- a/releases/35_FreqShift/info.yaml
+++ b/releases/35_FreqShift/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: FreqShift
-Description: Dual Input Frequency Shifter for Feedback Experimentation
+short-description: Dual Input Frequency Shifter for Feedback Experimentation
 Language: C++ (ComputerCard)
 Creator: Ben Regnier
 Version: 1.1

--- a/releases/36_GradualProcess/info.yaml
+++ b/releases/36_GradualProcess/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: GradualProcess
-Description: Three generative composition processes (Glass, Reich, Tintinnabuli) in one card, chosen by Main's position at power-on
+short-description: Three generative composition processes (Glass, Reich, Tintinnabuli) in one card, chosen by Main's position at power-on
 Language: C++ (ComputerCard)
 Creator: James Saunders
 Version: 1.0.0

--- a/releases/37_compulidean/info.yaml
+++ b/releases/37_compulidean/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Compulidean
-Description: Generative Euclidean drum + sample player.
+short-description: Generative Euclidean drum + sample player.
 Language: C++/Arduino, with vscode+platformio.
 Creator: Tristan Rowley
 Version: (see source repo)

--- a/releases/38_od/info.yaml
+++ b/releases/38_od/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Od
-Description: Loopable chaotic Lorenz attractor trajectories and zero-crossings as CV and pulses, with sensitivity to initial conditions.
+short-description: Loopable chaotic Lorenz attractor trajectories and zero-crossings as CV and pulses, with sensitivity to initial conditions.
 Language: MicroPython
 Creator: M. John Mills
 Version: 1.0

--- a/releases/39_knots/info.yaml
+++ b/releases/39_knots/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Knots
-Description: Six-engine oscillator firmware for the Music Thing Workshop System
+short-description: Six-engine oscillator firmware for the Music Thing Workshop System
 Language: C++ (RPi Pico SDK / ComputerCard)
 Creator: Jeff Fletcher
 Version: 0.2

--- a/releases/41_blackbird/info.yaml
+++ b/releases/41_blackbird/info.yaml
@@ -1,6 +1,6 @@
 draft: false
 Name: Blackbird
-Description: "A scriptable, live-codable, USB-serial-to-CV device implementing monome crow's protocol"
+short-description: "A scriptable, live-codable, USB-serial-to-CV device implementing monome crow's protocol"
 Language: Pico SDK + Lua
 Creator: Dune Desormeaux
 Version: 1.1

--- a/releases/42_backyard_rain/info.yaml
+++ b/releases/42_backyard_rain/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Backyard Rain
-Description: Nature soundscape audio. A cozy rain ambience mix for background listening. You control the intensity. This card plays rain ambience which was recorded in my backyard.
+short-description: Nature soundscape audio. A cozy rain ambience mix for background listening. You control the intensity. This card plays rain ambience which was recorded in my backyard.
 Language: Rust (Embassy framework)
 Creator: Brian Dorsey
 Version: (see source repo)

--- a/releases/433_sense_of_space/info.yaml
+++ b/releases/433_sense_of_space/info.yaml
@@ -1,5 +1,5 @@
 Name: 433 Sense of Space
-Description: "Whimsical 4'33\"-inspired ambience looper with a three-loop transport, LED countdown, restlessness fidgets, Pulse In restart, and chair creak one-shot."
+short-description: "Whimsical 4'33\"-inspired ambience looper with a three-loop transport, LED countdown, restlessness fidgets, Pulse In restart, and chair creak one-shot."
 Language: C++ (Pico SDK / ComputerCard)
 Creator: Music Thing Modular / AI-assisted
 Version: 0.2.1

--- a/releases/43_Castle_Process/info.yaml
+++ b/releases/43_Castle_Process/info.yaml
@@ -1,7 +1,7 @@
 id: 43_Castle_Process
 title: Castle Process
 draft: false
-Description: Fort Processor-inspired harsh noise processor with chopped external audio and a bass pulse voice
+short-description: Fort Processor-inspired harsh noise processor with chopped external audio and a bass pulse voice
 summary: >-
   Castle Process is a performance card built around chopped external audio, crude
   internal squarewave energy, aggressive switching between sources, and a separate

--- a/releases/44_Birds/info.yaml
+++ b/releases/44_Birds/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Birds
-Description: Two birds sing to each other controlled by a Turing-style shift register sequencer with clock in and CV/pulse out.
+short-description: Two birds sing to each other controlled by a Turing-style shift register sequencer with clock in and CV/pulse out.
 Language: C++ (Pico SDK / ComputerCard)
 Creator: Tom Whitwell
 Version: 0.5.0

--- a/releases/47_NZT/info.yaml
+++ b/releases/47_NZT/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: NZT
-Description: Grain Noise and Noise Tools
+short-description: Grain Noise and Noise Tools
 Language: C++ (ComputerCard)
 Creator: "@kjnilsson"
 Version: 1.0.0

--- a/releases/48_two_tracks/info.yaml
+++ b/releases/48_two_tracks/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Two Tracks
-Description: "Two Tracks — Dual-read-head phase looper. Record a mono loop to flash (IMA-ADPCM) and play it through two independent heads with separately controllable positions and loop lengths for evolving phase patterns and interference textures."
+short-description: "Two Tracks — Dual-read-head phase looper. Record a mono loop to flash (IMA-ADPCM) and play it through two independent heads with separately controllable positions and loop lengths for evolving phase patterns and interference textures."
 Language: C++ (Pico SDK)
 Creator: Joep Vermaat
 Version: 1.1

--- a/releases/50_flux/info.yaml
+++ b/releases/50_flux/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Flux
-Description: Effects, Synthesizer and Utility
+short-description: Effects, Synthesizer and Utility
 Language: C++ (RP2040 Pico SDK)
 Creator: Vincent Maurer
 Version: 1.0

--- a/releases/51_grains/info.yaml
+++ b/releases/51_grains/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Grains
-Description: Granular Sampler and Effect
+short-description: Granular Sampler and Effect
 Language: C++ (RP2040 Pico SDK)
 Creator: Vincent Maurer
 Version: 1.0

--- a/releases/53_glitter/info.yaml
+++ b/releases/53_glitter/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Glitter
-Description: Granular Looping Sampler
+short-description: Granular Looping Sampler
 Language: C++ (Pico SDK 2.1.1, UF2 release)
 Creator: Steve Jones
 Version: 0.1.2-beta

--- a/releases/54_Tapegrade/info.yaml
+++ b/releases/54_Tapegrade/info.yaml
@@ -6,7 +6,7 @@ date: 2026-06-14
 summary: >-
   Mono-input stereo cassette warble processor with wow, flutter, hiss, crackle, and tape
   wear morphing.
-description: >-
+short-description: >-
   Mono-input stereo cassette warble processor with wow, flutter, hiss, crackle, and tape
   wear morphing.
 

--- a/releases/55_fifths/info.yaml
+++ b/releases/55_fifths/info.yaml
@@ -1,6 +1,6 @@
 draft: false
 Name: Fifths
-Description: A quantizer/sequencer that can create harmony and nimbly traverse the circle of fifths in attempts to make jazz
+short-description: A quantizer/sequencer that can create harmony and nimbly traverse the circle of fifths in attempts to make jazz
 Language: C++ (RP2040 Pico SDK)
 Creator: Dune Desormeaux
 Version: 1.1

--- a/releases/56_Krell/info.yaml
+++ b/releases/56_Krell/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Krell
-Description: Krell
+short-description: Krell
 Language: Blackbird Lua
 Creator: Benjamin Reily
 Version: 1.0

--- a/releases/57_glitch/info.yaml
+++ b/releases/57_glitch/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Glitch
-Description: Clock-synced beat-repeater with ratcheting, reversal and audio degradation
+short-description: Clock-synced beat-repeater with ratcheting, reversal and audio degradation
 Language: C++ (RP2040 Pico SDK)
 Creator: Andy Jenkinson (uglifruit)
 Version: 1.4.0

--- a/releases/58_LoChoVibes/info.yaml
+++ b/releases/58_LoChoVibes/info.yaml
@@ -6,7 +6,7 @@ date: 2026-06-14
 summary: >-
   Stereo chorus and vibrato effect featuring triangle, sine, and slow drift LFO modes,
   modulation-based delay movement, and tape-style saturation.
-description: >-
+short-description: >-
   Stereo chorus and vibrato effect featuring triangle, sine, and slow drift LFO modes,
   modulation-based delay movement, and tape-style saturation.
 panel:

--- a/releases/59_BitPhase/info.yaml
+++ b/releases/59_BitPhase/info.yaml
@@ -3,7 +3,7 @@ title: BitPhase
 draft: false
 release: 59 / 0.1.0
 summary: Resonant 4-stage phaser with wide modulation sweeps, tremolo blending, and Burst-mode degradation
-description: Resonant 4-stage phaser for the Workshop Computer with deep notch filtering, wide modulation sweeps, controllable resonance, tremolo blending, and digital Burst-mode degradation.
+short-description: Resonant 4-stage phaser for the Workshop Computer with deep notch filtering, wide modulation sweeps, controllable resonance, tremolo blending, and digital Burst-mode degradation.
 date: 2026-06-24
 
 panel:

--- a/releases/60_markov/info.yaml
+++ b/releases/60_markov/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Markov
-Description: Dual generative Markov chain module — evolving melody (MarkoV) left side, rhythmic percussion patterns (MarkovPerc) right side, with internal synth voice
+short-description: Dual generative Markov chain module — evolving melody (MarkoV) left side, rhythmic percussion patterns (MarkovPerc) right side, with internal synth voice
 Language: C++ (Pico SDK)
 Creator: Andy Jenkinson (uglifruit)
 Version: 1.0.0

--- a/releases/64_voices_of_sid/info.yaml
+++ b/releases/64_voices_of_sid/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Voices of SID
-Description: "Dual MOS 6581 SID emulation (reSID engine) with CV/gate control, stereo output, waveform selection, and randomize"
+short-description: "Dual MOS 6581 SID emulation (reSID engine) with CV/gate control, stereo output, waveform selection, and randomize"
 Language: C++ (Pico SDK)
 Creator: Joep Vermaat
 Version: 1.1

--- a/releases/66_stretchcore/info.yaml
+++ b/releases/66_stretchcore/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Stretchcore
-Description: A card for playing and manipulating samples with tempo control, timestretch with browser-based audio loading (infinitedigits.com/stretchcore/)
+short-description: A card for playing and manipulating samples with tempo control, timestretch with browser-based audio loading (infinitedigits.com/stretchcore/)
 Language: C++ (Pico SDK)
 Creator: Infinite Digits
 Version: 1.0

--- a/releases/67_Fragments/info.yaml
+++ b/releases/67_Fragments/info.yaml
@@ -1,4 +1,5 @@
-Description: Six-slot audio recorder and clocked fragment sequencer with browser librarian, MIDI pitch control, random CV outputs, and an alternate long-sample variation mode.
+short-description: Six-slot audio recorder and clocked fragment sequencer with browser librarian, MIDI pitch control, random CV outputs, and an alternate long-sample variation mode.
+summary: Six-slot audio recorder and clocked fragment sequencer with browser librarian, MIDI pitch control, random CV outputs, and an alternate long-sample variation mode.
 Name: Fragments
 Language: C++ (RPi Pico SDK)
 Creator: Max Harnishfeger

--- a/releases/69_trace/info.yaml
+++ b/releases/69_trace/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Trace
-Description: Oscillograph stereo oscillator
+short-description: Oscillograph stereo oscillator
 Language: C++ (ComputerCard)
 Creator: Ruiyang Wang
 Version: 0.1

--- a/releases/71_degenerator/info.yaml
+++ b/releases/71_degenerator/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Degenerator
-Description: "Degenerator — Disintegrating Looper. Capture audio loops and apply irreversible degradation with 6 algorithms (Saturation, Filter Drift, Tape Hiss, Oxide Shedding, Bit Crush, Bit Rot) via preview/apply workflow. Inspired by William Basinski's The Disintegration Loops."
+short-description: "Degenerator — Disintegrating Looper. Capture audio loops and apply irreversible degradation with 6 algorithms (Saturation, Filter Drift, Tape Hiss, Oxide Shedding, Bit Crush, Bit Rot) via preview/apply workflow. Inspired by William Basinski's The Disintegration Loops."
 Language: C++ (Pico SDK)
 Creator: Joep Vermaat
 Version: 1.3

--- a/releases/72_motorik/info.yaml
+++ b/releases/72_motorik/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Motorik
-Description: Motorik drum machine — kick/snare/hihat with bass and melody CV, classic Krautrock grooves
+short-description: Motorik drum machine — kick/snare/hihat with bass and melody CV, classic Krautrock grooves
 Language: C++ (Pico SDK)
 Creator: Joep Vermaat
 Version: 1.0

--- a/releases/73_VSS/info.yaml
+++ b/releases/73_VSS/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: VSS
-Description: 6-voice polyphonic µ-law sampler inspired by the Yamaha VSS-30
+short-description: 6-voice polyphonic µ-law sampler inspired by the Yamaha VSS-30
 Language: C++ (ComputerCard)
 Creator: "@kjnilsson"
 Version: 1.0.0

--- a/releases/74_Wild_Pebble/info.yaml
+++ b/releases/74_Wild_Pebble/info.yaml
@@ -3,7 +3,7 @@ title: Wild Pebble
 draft: false
 release: 74 / 1.0
 summary: MIDI-clockable generative rhythm and melody organism inspired by Pet Rock
-description: MIDI-clockable generative rhythm and melody organism inspired by Pet Rock
+short-description: MIDI-clockable generative rhythm and melody organism inspired by Pet Rock
 date: 2026-06-14
 panel:
   controls:

--- a/releases/75_Turing_Clouds/info.yaml
+++ b/releases/75_Turing_Clouds/info.yaml
@@ -1,4 +1,5 @@
-Description: Turing Machine-driven granular texture generator and rhythmic delay for the Workshop Computer
+short-description: Turing Machine-driven granular texture generator and rhythmic delay for the Workshop Computer
+summary: Turing Machine-driven granular texture generator and rhythmic delay for the Workshop Computer
 Name: Turing Clouds
 Language: C++ (Pico SDK)
 Creator: Ainews

--- a/releases/76_hot_fuzz/info.yaml
+++ b/releases/76_hot_fuzz/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Hot Fuzz
-Description: A stereo fuzz/distortion + resonant wah effects processor with manual and auto-wah modes, built on fixed-point DSP.
+short-description: A stereo fuzz/distortion + resonant wah effects processor with manual and auto-wah modes, built on fixed-point DSP.
 Language: C++ (ComputerCard)
 Creator: Joep Vermaat
 Version: 1.0

--- a/releases/77_Placeholder/info.yaml
+++ b/releases/77_Placeholder/info.yaml
@@ -1,6 +1,7 @@
 draft: true
 Name: Placeholder
-Description: Reserved for secret project
+short-description: Reserved for secret project
+summary: Reserved for secret project
 Language: None
 Creator: None
 Version: 0.0

--- a/releases/78_Talker/info.yaml
+++ b/releases/78_Talker/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Talker
-Description: Proof of concept speech synthesizer, based on TalkiePCM, inspired by 1970s LPC speech synths.
+short-description: Proof of concept speech synthesizer, based on TalkiePCM, inspired by 1970s LPC speech synths.
 Language: C++ (ComputerCard)
 Creator: Chris Johnson
 Version: 0.1

--- a/releases/81_West_Coast_LPG/info.yaml
+++ b/releases/81_West_Coast_LPG/info.yaml
@@ -1,4 +1,5 @@
-Description: "Dual vactrol-emulating low-pass gate (combined VCA + low-pass filter) with fast-attack/slow-decay 'plong', self-pinging percussion, and per-channel VCA/VCF/LPG modes."
+short-description: "Dual vactrol-emulating low-pass gate (combined VCA + low-pass filter) with fast-attack/slow-decay 'plong', self-pinging percussion, and per-channel VCA/VCF/LPG modes."
+summary: "Dual vactrol-emulating low-pass gate (combined VCA + low-pass filter) with fast-attack/slow-decay 'plong', self-pinging percussion, and per-channel VCA/VCF/LPG modes."
 Name: West Coast LPG
 Language: "C++ (ComputerCard)"
 Creator: "Jason Moore"

--- a/releases/82_Computer_Grids/info.yaml
+++ b/releases/82_Computer_Grids/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Computer Grids
-Description: Grids-inspired trigger sequencer with Web MIDI SysEx configuration.
+short-description: Grids-inspired trigger sequencer with Web MIDI SysEx configuration.
 Language: C++
 Creator: Phil Miller
 Version: 0.1.0

--- a/releases/83_Origami/info.yaml
+++ b/releases/83_Origami/info.yaml
@@ -1,4 +1,5 @@
-Description: "Dual oversampled wavefolder — triangle / sine / hard-clip folding with bias (even-harmonic) control and CV over fold depth, band-limited via 4x oversampling."
+short-description: "Dual oversampled wavefolder — triangle / sine / hard-clip folding with bias (even-harmonic) control and CV over fold depth, band-limited via 4x oversampling."
+summary: "Dual oversampled wavefolder — triangle / sine / hard-clip folding with bias (even-harmonic) control and CV over fold depth, band-limited via 4x oversampling."
 Name: Origami
 Language: "C++ (ComputerCard)"
 Creator: "Jason Moore"

--- a/releases/84_CosmikC1zzl3/info.yaml
+++ b/releases/84_CosmikC1zzl3/info.yaml
@@ -7,7 +7,7 @@ summary: >-
   Stable phase-distortion synthesiser and Turing machine firmware with Web MIDI
   envelope readback, PD, detune, eight waveform families, hosted CZ patch
   import, USB MIDI device/host operation, and optional Turing MIDI output.
-description: >-
+short-description: >-
   Stable phase-distortion synthesiser and Turing machine firmware with Web MIDI
   envelope readback, PD, detune, eight waveform families, hosted CZ patch
   import, USB MIDI device/host operation, and optional Turing MIDI output.

--- a/releases/86_tesserae/info.yaml
+++ b/releases/86_tesserae/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Tesserae
-Description: "Tesserae — Variable-voice (2-8) arpeggiated chord generator with 5 patterns, 10 scales, tap tempo, CV/audio transpose inputs, and dual CV + audio pitch outputs. Inspired by Laurie Spiegel's Music Mouse and Patchwork."
+short-description: "Tesserae — Variable-voice (2-8) arpeggiated chord generator with 5 patterns, 10 scales, tap tempo, CV/audio transpose inputs, and dual CV + audio pitch outputs. Inspired by Laurie Spiegel's Music Mouse and Patchwork."
 Language: C++ (Pico SDK)
 Creator: Joep Vermaat
 Version: 1.0

--- a/releases/87_fr330hfr33/info.yaml
+++ b/releases/87_fr330hfr33/info.yaml
@@ -2,7 +2,7 @@ id: Fr330hfr33
 title: Fr330hfr33
 release: 87 / 0.9.3
 summary: Performance-focused acid voice with diode filtering, distortion, MIDI, and a persistent sequencer
-description: Hardware-tested acid bass synthesiser with selectable saw or square oscillator, switchable 18 or 24 dB diode-style filtering, accent and glide, distortion, USB MIDI device/host operation, and a persistent editable sequencer.
+short-description: Hardware-tested acid bass synthesiser with selectable saw or square oscillator, switchable 18 or 24 dB diode-style filtering, accent and glide, distortion, USB MIDI device/host operation, and a persistent editable sequencer.
 date: 2026-06-21
 panel:
   controls:

--- a/releases/88_Blank/info.yaml
+++ b/releases/88_Blank/info.yaml
@@ -1,6 +1,7 @@
 draft: true
 Name: Blank
-Description: Reserved for blank 88 cards
+short-description: Reserved for blank 88 cards
+summary: Reserved for blank 88 cards
 Language: None
 Creator: Tom Whitwell
 Version: 0

--- a/releases/90_Pantograph/info.yaml
+++ b/releases/90_Pantograph/info.yaml
@@ -1,6 +1,6 @@
 draft: false
 Name: Pantograph
-Description: Trace and record CV — record knob movements, loop them at bipolar speed
+short-description: Trace and record CV — record knob movements, loop them at bipolar speed
 Language: Pico SDK
 Creator: Kenny Shen
 Version: 1.1

--- a/releases/91_chorgan/info.yaml
+++ b/releases/91_chorgan/info.yaml
@@ -1,5 +1,5 @@
 Name: Chorgan
-Description: "Chorgan — 6-voice chord synthesizer with morphing timbre, chord extension presets, and built-in chord sequencer. Two modes: normal (detune/chorus) and slew (portamento chord changes). Inspired by the Music Thing Modular Chord Organ."
+short-description: "Chorgan — 6-voice chord synthesizer with morphing timbre, chord extension presets, and built-in chord sequencer. Two modes: normal (detune/chorus) and slew (portamento chord changes). Inspired by the Music Thing Modular Chord Organ."
 Language: C++ (Pico SDK / ComputerCard)
 Creator: Andy Jenkinson (uglifruit)
 Version: 1.1.0

--- a/releases/93_Turing_Matrix/info.yaml
+++ b/releases/93_Turing_Matrix/info.yaml
@@ -3,7 +3,7 @@ title: Turing Matrix
 draft: false
 release: 93 / 0.1.0-beta
 summary: Turing Machine sequencer with a switchable mixer layer inspired by the Music Thing Modular Turing Machine and Vactrol Mix combination
-description: Turing Machine sequencer with a switchable mixer layer inspired by the Music Thing Modular Turing Machine and Vactrol Mix combination
+short-description: Turing Machine sequencer with a switchable mixer layer inspired by the Music Thing Modular Turing Machine and Vactrol Mix combination
 date: 2026-06-26
 panel:
   controls:

--- a/releases/95_offair2/info.yaml
+++ b/releases/95_offair2/info.yaml
@@ -1,5 +1,5 @@
 Name: OffAir
-Description: "OffAir — AM/Shortwave/Longwave radio simulator. Tune between two Stations and interference with authentic heterodyne whistles, SSB pitch-shift detuning, AM envelope detection, swelling per-band static, and triggerable Insta-ference one-shots. Baked recordings or live audio inputs become the Stations."
+short-description: "OffAir — AM/Shortwave/Longwave radio simulator. Tune between two Stations and interference with authentic heterodyne whistles, SSB pitch-shift detuning, AM envelope detection, swelling per-band static, and triggerable Insta-ference one-shots. Baked recordings or live audio inputs become the Stations."
 Language: C++ (Pico SDK / ComputerCard)
 Creator: Andy Jenkinson (uglifruit)
 Version: 1.0.1

--- a/releases/96_cathode/info.yaml
+++ b/releases/96_cathode/info.yaml
@@ -1,6 +1,6 @@
 draft: false
 Name: Cathode Ray
-Description: Composite video synthesiser (PAL + NTSC builds) — oscilloscope, etch-a-sketch & spectrum analyser, greyscale via dithering, performance effects, 8 alt-boot screensaver/game modes
+short-description: Composite video synthesiser (PAL + NTSC builds) — oscilloscope, etch-a-sketch & spectrum analyser, greyscale via dithering, performance effects, 8 alt-boot screensaver/game modes
 Language: C++ (RP2040 Pico SDK)
 Creator: Andy Jenkinson (uglifruit)
 Version: 1.2.0

--- a/releases/97_alloy/info.yaml
+++ b/releases/97_alloy/info.yaml
@@ -1,6 +1,6 @@
 draft: false
 Name: Alloy
-Description: Fixed-point 15-zone cross-modulator with a clocked Turing CV and gate companion.
+short-description: Fixed-point 15-zone cross-modulator with a clocked Turing CV and gate companion.
 Language: C++ (RP2040 Pico SDK)
 Creator: Eric Gao
 Version: 0.2.0

--- a/releases/98_duo_midi/info.yaml
+++ b/releases/98_duo_midi/info.yaml
@@ -1,6 +1,6 @@
 draft: false
 Name: Duo MIDI
-Description: A duophonic midi device/host interface
+short-description: A duophonic midi device/host interface
 Language: Lua / Blackbird
 Creator: Dune Desormeaux
 Version: 0.1

--- a/releases/99_toolbox/info.yaml
+++ b/releases/99_toolbox/info.yaml
@@ -1,6 +1,6 @@
 draft: true
 Name: Toolbox
-Description: Mixer, VCA, noise, S&H, clock generator, etc.
+short-description: Mixer, VCA, noise, S&H, clock generator, etc.
 Language: C++ (ComputerCard)
 Creator: divmod
 Version: 0.1.1


### PR DESCRIPTION
Updates info.yaml.md schema to clarify the uses of certain field:

Description is really a one-liner. Renamed to short-description

summary remains as the longer explanation.