### PR TITLE
61_ZX_Spectrum: add web editor URL + fix web-app link

### DIFF
--- a/releases/61_ZX_Spectrum/README.md
+++ b/releases/61_ZX_Spectrum/README.md
@@ -122,9 +122,9 @@ Start from it. (`snapshots/bakedasm.z80` is the assembled version that gets bake
 
 USB-MIDI / WebMIDI SysEx — **Chrome or Edge**, no install.
 
-> **The web app is the file [`interface.html`](interface.html)** (repo root). Open it
-> in Chrome/Edge, plug the card into USB, and click **Connect**. (Pause the card —
-> switch Up — while uploading.)
+> **Open the web app: <https://uglifruit.github.io/WorkshopZX/interface.html>**
+> (or the local [`interface.html`](interface.html) copy). Chrome/Edge, plug the card
+> into USB, click **Connect**. Pause the card (switch Up) while uploading.
 
 - **Upload** `.z80` / `.sna` / `.ay` / `.pt3`.
 - **Remap** inputs on a clickable QWERTY keyboard, with **Kempston**, **→ Port** and

--- a/releases/61_ZX_Spectrum/info.yaml
+++ b/releases/61_ZX_Spectrum/info.yaml
@@ -7,6 +7,7 @@ Version: 1.0.0
 Status: Released
 License: MIT (card source); vendored components keep their own licences
 Repository: https://github.com/uglifruit/WorkshopZX
+Editor: https://uglifruit.github.io/WorkshopZX/interface.html
 date: 2026-07-26
 
 tags:


### PR DESCRIPTION
Small follow-up to #273 (61_ZX_Spectrum).

The generated program page ([61-zx-spectrum](https://tomwhitwell.github.io/Workshop_Computer/programs/61-zx-spectrum/index.html)) needs a hosted, browser-executable **web editor URL** — the previous version had none, so the README's link pointed at the raw GitHub file, which browsers serve as `text/plain` (it opened as raw text instead of running).

This adds:
- `Editor: https://uglifruit.github.io/WorkshopZX/interface.html` to `info.yaml` (the web app is now hosted on the card's own repo via GitHub Pages).
- Fixes the README web-app link to that hosted URL.

Docs-only; no firmware change.