### PR TITLE
Info yaml updates

### DIFF
--- a/releases/29_XHT/README.md
+++ b/releases/29_XHT/README.md
@@ -54,3 +54,9 @@ MIDI build additions:
 - In current active builds, `CV Out 1` mirrors note position unless `CV1` is patched, when it becomes pitch; `CV Out 2` always mirrors note position.
 - In current active builds, analog `CV2` is scaled so 0-5V controller/mod-wheel sources can cover the full note-position travel.
 - Pulse Out 1 mirrors note gate behavior and Pulse Out 2 mirrors the `P2` input pulse.
+
+## Attribution
+
+This card uses the ComputerCard hardware framework by Chris Johnson. Its USB
+MIDI host support includes the MIT-licensed rppicomidi files, copyright 2023
+rppicomidi; their copyright and licence notices are retained in the source.

--- a/releases/29_XHT/info.yaml
+++ b/releases/29_XHT/info.yaml
@@ -4,7 +4,7 @@ short-description: A playable deep-note-inspired stereo chord swarm with manual 
 Language: C++ (Pico SDK)
 Creator: Adrian Vos
 Version: 0.1.0
-Status: Beta
+Status: Beta - stable in single-developer testing
 License: GPL-3.0
 date-created: 2026-07-11
 date-updated: 2026-07-12

--- a/releases/34_dual_quant/info.yaml
+++ b/releases/34_dual_quant/info.yaml
@@ -1,9 +1,14 @@
 id: 34_dual_quant
-title: DualQuant
+Name: DualQuant
 draft: false
 release: 34 / 1.0
 summary: Dual quantised granular pitch shifter with calibrated 1V/oct CV outputs
 short-description: Dual quantised granular pitch shifter with calibrated 1V/oct CV outputs
+Language: C++ (ComputerCard / Pico SDK)
+Creator: Adrian Vos
+Version: "1.0"
+Status: Beta
+License: MIT
 date-created: 2026-06-14
 date-updated: 2026-06-15
 panel:

--- a/releases/34_dual_quant/info.yaml
+++ b/releases/34_dual_quant/info.yaml
@@ -7,7 +7,7 @@ short-description: Dual quantised granular pitch shifter with calibrated 1V/oct 
 Language: C++ (ComputerCard / Pico SDK)
 Creator: Adrian Vos
 Version: "1.0"
-Status: Beta
+Status: Beta - stable in single-developer testing
 License: MIT
 date-created: 2026-06-14
 date-updated: 2026-06-15
@@ -89,7 +89,7 @@ metadata:
   creator: Adrian Vos
   language: C++ (ComputerCard / Pico SDK)
   version: 1
-  status: Beta
+  status: Beta - stable in single-developer testing
   license: MIT
 documentation:
   intro: >

--- a/releases/433_sense_of_space/README.md
+++ b/releases/433_sense_of_space/README.md
@@ -148,3 +148,7 @@ interpolated to the Workshop Computer's 48 kHz audio rate, then sent through the
 integer Dattorro-style reverb from Reverb+. The X control deliberately avoids the
 near-freeze end of the reverb algorithm so the largest setting remains musical
 rather than turning the quiet ambience into noise.
+
+The integer reverb implementation is based on Jon Dattorro's reverb design and
+the [el-visio/dattorro-verb](https://github.com/el-visio/dattorro-verb)
+reference implementation; the source retains its attribution comment.

--- a/releases/433_sense_of_space/info.yaml
+++ b/releases/433_sense_of_space/info.yaml
@@ -3,7 +3,7 @@ short-description: "Whimsical 4'33\"-inspired ambience looper with a three-loop 
 Language: C++ (Pico SDK / ComputerCard)
 Creator: Adrian Vos
 Version: 0.2.1
-Status: stable
+Status: Beta - stable in single-developer testing
 License: Mixed - source code/reverb components follow their original project licences; embedded BBC Sound Effects audio is subject to BBC Sound Effects Archive licensing
 date-created: 2026-07-14
 date-updated: 2026-07-16

--- a/releases/433_sense_of_space/info.yaml
+++ b/releases/433_sense_of_space/info.yaml
@@ -1,7 +1,7 @@
 Name: 433 Sense of Space
 short-description: "Whimsical 4'33\"-inspired ambience looper with a three-loop transport, LED countdown, restlessness fidgets, Pulse In restart, and chair creak one-shot."
 Language: C++ (Pico SDK / ComputerCard)
-Creator: Music Thing Modular / AI-assisted
+Creator: Adrian Vos
 Version: 0.2.1
 Status: stable
 License: Mixed - source code/reverb components follow their original project licences; embedded BBC Sound Effects audio is subject to BBC Sound Effects Archive licensing

--- a/releases/433_sense_of_space/mayakovsky_cc0/README.md
+++ b/releases/433_sense_of_space/mayakovsky_cc0/README.md
@@ -128,3 +128,7 @@ interpolated to the Workshop Computer's 48 kHz audio rate, then sent through the
 integer Dattorro-style reverb from Reverb+. The X control deliberately avoids the
 near-freeze end of the reverb algorithm so the largest setting remains musical
 rather than turning the quiet ambience into noise.
+
+The integer reverb implementation is based on Jon Dattorro's reverb design and
+the [el-visio/dattorro-verb](https://github.com/el-visio/dattorro-verb)
+reference implementation; the source retains its attribution comment.

--- a/releases/433_sense_of_space/mayakovsky_cc0/info.yaml
+++ b/releases/433_sense_of_space/mayakovsky_cc0/info.yaml
@@ -1,7 +1,7 @@
 Name: 433 Sense of Space - Mayakovsky CC0 Version
-Description: "CC0 variant using Mayakovsky Theatre audience ambience from approximately 4:45, with the same three-loop 4'33\" transport and controls."
+short-description: "CC0 variant using Mayakovsky Theatre audience ambience with the same three-loop 4'33\" transport and controls."
 Language: C++ (Pico SDK / ComputerCard)
-Creator: Music Thing Modular / AI-assisted
+Creator: Adrian Vos
 Version: 0.2.1-mayakovsky-cc0
 Status: stable
 License: Mixed - embedded ambience and seat creak audio are Creative Commons 0; source code/reverb components follow their original project licences

--- a/releases/433_sense_of_space/mayakovsky_cc0/info.yaml
+++ b/releases/433_sense_of_space/mayakovsky_cc0/info.yaml
@@ -3,7 +3,7 @@ short-description: "CC0 variant using Mayakovsky Theatre audience ambience with 
 Language: C++ (Pico SDK / ComputerCard)
 Creator: Adrian Vos
 Version: 0.2.1-mayakovsky-cc0
-Status: stable
+Status: Beta - stable in single-developer testing
 License: Mixed - embedded ambience and seat creak audio are Creative Commons 0; source code/reverb components follow their original project licences
 license-notes: Embedded ambience is derived from Freesound sound 347832 by gladkiy, licensed CC0.
 

--- a/releases/43_Castle_Process/README.md
+++ b/releases/43_Castle_Process/README.md
@@ -110,3 +110,7 @@ Internal chop pulse output.
 * trigger `Pulse In 1` from a sequencer or clock divider for controlled bass rhythms
 * use switch `Down` as a manual performance accent
 
+## Attribution
+
+Castle Process uses the ComputerCard hardware framework by Chris Johnson. The
+framework's original notice is retained in `ComputerCard.h`.

--- a/releases/43_Castle_Process/info.yaml
+++ b/releases/43_Castle_Process/info.yaml
@@ -10,7 +10,7 @@ summary: >-
 Language: C++
 Creator: Adrian Vos
 Version: "1.0"
-Status: Release Candidate
+Status: Beta - stable in single-developer testing
 release: 43 / 0.9.0
 License: MIT
 date-created: 2026-06-25
@@ -140,4 +140,4 @@ metadata:
   creator: Adrian Vos
   language: C++
   version: 1.0
-  status: Release Candidate
+  status: Beta - stable in single-developer testing

--- a/releases/43_Castle_Process/info.yaml
+++ b/releases/43_Castle_Process/info.yaml
@@ -1,5 +1,5 @@
 id: 43_Castle_Process
-title: Castle Process
+Name: Castle Process
 draft: false
 short-description: Fort Processor-inspired harsh noise processor with chopped external audio and a bass pulse voice
 summary: >-
@@ -9,6 +9,8 @@ summary: >-
   a clean effect or faithful clone.
 Language: C++
 Creator: Adrian Vos
+Version: "1.0"
+Status: Release Candidate
 release: 43 / 0.9.0
 License: MIT
 date-created: 2026-06-25

--- a/releases/54_Tapegrade/README.md
+++ b/releases/54_Tapegrade/README.md
@@ -173,3 +173,8 @@ Heavy degradation with strong hiss, crackle, and unstable tape behaviour.
 * Pulse inputs can be clocked or triggered rhythmically
 * CV outputs operate independently from the audio path
 * Optimised for Workshop Computer hardware
+
+## Attribution
+
+Tapegrade uses the ComputerCard hardware framework by Chris Johnson. The
+framework's original notice is retained in `ComputerCard.h`.

--- a/releases/54_Tapegrade/info.yaml
+++ b/releases/54_Tapegrade/info.yaml
@@ -1,5 +1,5 @@
 id: Tapegrade
-title: Tapegrade
+Name: Tapegrade
 draft: false
 release: 54 / 0.8.0
 date-created: 2026-06-14
@@ -10,6 +10,11 @@ summary: >-
 short-description: >-
   Mono-input stereo cassette warble processor with wow, flutter, hiss, crackle, and tape
   wear morphing.
+Language: C++ (RP2040 Pico SDK)
+Creator: Adrian Vos
+Version: "0.8.0"
+Status: WIP
+License: MIT
 
 panel:
   controls:

--- a/releases/54_Tapegrade/info.yaml
+++ b/releases/54_Tapegrade/info.yaml
@@ -13,7 +13,7 @@ short-description: >-
 Language: C++ (RP2040 Pico SDK)
 Creator: Adrian Vos
 Version: "0.8.0"
-Status: WIP
+Status: Beta - stable in single-developer testing
 License: MIT
 
 panel:
@@ -130,7 +130,7 @@ metadata:
   creator: Adrian Vos
   language: C++ (RP2040 Pico SDK)
   version: 0.8.0
-  status: WIP (functional)
+  status: Beta - stable in single-developer testing
   license: MIT
 documentation:
   intro: >

--- a/releases/58_LoChoVibes/README.md
+++ b/releases/58_LoChoVibes/README.md
@@ -322,3 +322,8 @@ LED brightness reflects both parameter values and modulation movement, providing
 # Current Status
 
 Actively under development and testing.
+
+## Attribution
+
+LoCho Vibes uses the ComputerCard hardware framework by Chris Johnson. The
+framework's original notice is retained in `ComputerCard.h`.

--- a/releases/58_LoChoVibes/info.yaml
+++ b/releases/58_LoChoVibes/info.yaml
@@ -13,7 +13,7 @@ short-description: >-
 Language: C++
 Creator: Adrian Vos
 Version: "0.1.0"
-Status: Released
+Status: Beta - stable in single-developer testing
 License: MIT
 panel:
   controls:
@@ -124,7 +124,7 @@ metadata:
   creator: Adrian Vos
   language: C++
   version: 0.1.0
-  status: released
+  status: Beta - stable in single-developer testing
   license: MIT
 documentation:
   intro: |

--- a/releases/58_LoChoVibes/info.yaml
+++ b/releases/58_LoChoVibes/info.yaml
@@ -1,5 +1,5 @@
 id: 58_LoChoVibes
-title: LoCho Vibes
+Name: LoCho Vibes
 draft: false
 release: 58 / 0.1.0
 date-created: 2026-06-14
@@ -10,6 +10,11 @@ summary: >-
 short-description: >-
   Stereo chorus and vibrato effect featuring triangle, sine, and slow drift LFO modes,
   modulation-based delay movement, and tape-style saturation.
+Language: C++
+Creator: Adrian Vos
+Version: "0.1.0"
+Status: Released
+License: MIT
 panel:
   controls:
     main:

--- a/releases/59_BitPhase/README.md
+++ b/releases/59_BitPhase/README.md
@@ -244,4 +244,9 @@ Useful for synchronising external modulation events.
 * LED 5 — Burst mode status
 * LED 6 — Pulse input monitor
 
+## Attribution
+
+BitPhase uses the ComputerCard hardware framework by Chris Johnson. The
+framework's original notice is retained in `ComputerCard.h`.
+
 ---

--- a/releases/59_BitPhase/info.yaml
+++ b/releases/59_BitPhase/info.yaml
@@ -7,7 +7,7 @@ short-description: Resonant 4-stage phaser for the Workshop Computer with deep n
 Language: C++ (Pico SDK)
 Creator: Adrian Vos
 Version: "0.1.0"
-Status: Beta
+Status: Beta - stable in single-developer testing
 License: MIT
 date-created: 2026-06-24
 date-updated: 2026-07-09
@@ -120,7 +120,7 @@ metadata:
   creator: Adrian Vos
   language: C++ (Pico SDK)
   version: 0.1.0
-  status: Beta
+  status: Beta - stable in single-developer testing
   license: MIT
 documentation:
   intro: >

--- a/releases/59_BitPhase/info.yaml
+++ b/releases/59_BitPhase/info.yaml
@@ -1,9 +1,14 @@
 id: BitPhase
-title: BitPhase
+Name: BitPhase
 draft: false
 release: 59 / 0.1.0
 summary: Resonant 4-stage phaser with wide modulation sweeps, tremolo blending, and Burst-mode degradation
 short-description: Resonant 4-stage phaser for the Workshop Computer with deep notch filtering, wide modulation sweeps, controllable resonance, tremolo blending, and digital Burst-mode degradation.
+Language: C++ (Pico SDK)
+Creator: Adrian Vos
+Version: "0.1.0"
+Status: Beta
+License: MIT
 date-created: 2026-06-24
 date-updated: 2026-07-09
 

--- a/releases/74_Wild_Pebble/README.md
+++ b/releases/74_Wild_Pebble/README.md
@@ -218,3 +218,9 @@ The MIDI implementation is intentionally small:
 * no configurable MIDI channel yet
 
 The analogue behavior remains the same unless MIDI clock is connected and running.
+
+## Attribution
+
+Wild Pebble uses the ComputerCard hardware framework by Chris Johnson and the
+TinyUSB components supplied with the Raspberry Pi Pico SDK. Their respective
+licence notices remain with the source dependencies.

--- a/releases/74_Wild_Pebble/info.yaml
+++ b/releases/74_Wild_Pebble/info.yaml
@@ -7,7 +7,7 @@ short-description: MIDI-clockable generative rhythm and melody organism inspired
 Language: C++
 Creator: Adrian Vos
 Version: "1.0"
-Status: Beta
+Status: Beta - stable in single-developer testing
 License: GPL-3.0
 date-created: 2026-06-14
 date-updated: 2026-06-25
@@ -107,7 +107,7 @@ metadata:
   creator: Adrian Vos
   language: C++
   version: 1
-  status: Beta. USB MIDI clock input and sequencer note output tested
+  status: Beta - stable in single-developer testing
   license: GPL-3.0
 documentation:
   intro: >

--- a/releases/74_Wild_Pebble/info.yaml
+++ b/releases/74_Wild_Pebble/info.yaml
@@ -1,9 +1,14 @@
 id: 74_Wild_Pebble
-title: Wild Pebble
+Name: Wild Pebble
 draft: false
 release: 74 / 1.0
 summary: MIDI-clockable generative rhythm and melody organism inspired by Pet Rock
 short-description: MIDI-clockable generative rhythm and melody organism inspired by Pet Rock
+Language: C++
+Creator: Adrian Vos
+Version: "1.0"
+Status: Beta
+License: GPL-3.0
 date-created: 2026-06-14
 date-updated: 2026-06-25
 panel:
@@ -99,7 +104,7 @@ readme_url: >-
 download_url: >-
   https://raw.githubusercontent.com/TomWhitwell/Workshop_Computer/main/releases/74_Wild_Pebble/UF2/WildPebble.uf2
 metadata:
-  creator: Adrian Vos with Vibecode support
+  creator: Adrian Vos
   language: C++
   version: 1
   status: Beta. USB MIDI clock input and sequencer note output tested

--- a/releases/84_CosmikC1zzl3/README.md
+++ b/releases/84_CosmikC1zzl3/README.md
@@ -243,3 +243,7 @@ removed; Y is the Turing internal clock control.
 This project is released under the MIT License. The included `computercard.h`
 hardware helper is ComputerCard by Chris Johnson and is also MIT licensed; keep
 its MIT notice present when copying firmware files into releases or experiments.
+
+USB MIDI host support includes the MIT-licensed rppicomidi files, copyright
+2023 rppicomidi. Their copyright and licence notices are retained in the
+corresponding source files.

--- a/releases/84_CosmikC1zzl3/info.yaml
+++ b/releases/84_CosmikC1zzl3/info.yaml
@@ -1,5 +1,5 @@
 id: 84_CosmikC1zzl3
-title: Cosmik C1ZZL3
+Name: Cosmik C1ZZL3
 draft: false
 release: 84 / 1.4
 date-created: 2026-07-22
@@ -14,6 +14,11 @@ short-description: >-
   pitch-aware Web MIDI envelopes, envelope readback, PD, detune, eight waveform
   families, hosted CZ patch import, USB MIDI device/host operation, and optional
   Turing MIDI output that defaults off.
+Language: C++ (Pico SDK)
+Creator: Adrian Vos
+Version: "1.4"
+Status: Released
+License: MIT
 panel:
   controls:
     main:

--- a/releases/84_CosmikC1zzl3/info.yaml
+++ b/releases/84_CosmikC1zzl3/info.yaml
@@ -17,7 +17,7 @@ short-description: >-
 Language: C++ (Pico SDK)
 Creator: Adrian Vos
 Version: "1.4"
-Status: Released
+Status: Beta - stable in single-developer testing
 License: MIT
 panel:
   controls:
@@ -148,7 +148,7 @@ metadata:
   creator: Adrian Vos
   language: C++ (Pico SDK)
   version: 1.4
-  status: Released
+  status: Beta - stable in single-developer testing
   license: MIT
   editor_url: https://tomwhitwell.github.io/Workshop_Computer/programs/84-cosmikc1zzl3/web/index.html
   editor_note: Configure this card in Envelope Lab; use web/import/index.html for CZ patch translation.

--- a/releases/87_fr330hfr33/README.md
+++ b/releases/87_fr330hfr33/README.md
@@ -210,3 +210,9 @@ optional.
 
 The Web MIDI SysEx format is documented in
 [`protocol.md`](protocol.md).
+
+## Attribution
+
+Fr330hfr33 uses the ComputerCard hardware framework by Chris Johnson. Its USB
+MIDI host support includes the MIT-licensed rppicomidi files, copyright 2023
+rppicomidi; their copyright and licence notices are retained in the source.

--- a/releases/87_fr330hfr33/info.yaml
+++ b/releases/87_fr330hfr33/info.yaml
@@ -1,8 +1,12 @@
 id: Fr330hfr33
-title: Fr330hfr33
+Name: Fr330hfr33
 release: 87 / 0.9.3
 summary: Performance-focused acid voice with diode filtering, distortion, MIDI, and a persistent sequencer
 short-description: Hardware-tested acid bass synthesiser with selectable saw or square oscillator, switchable 18 or 24 dB diode-style filtering, accent and glide, distortion, USB MIDI device/host operation, and a persistent editable sequencer.
+Language: Pico SDK
+Creator: Adrian Vos
+Version: "0.9.3"
+Status: Stable
 date-created: 2026-06-21
 date-updated: 2026-07-13
 panel:

--- a/releases/87_fr330hfr33/info.yaml
+++ b/releases/87_fr330hfr33/info.yaml
@@ -6,7 +6,7 @@ short-description: Hardware-tested acid bass synthesiser with selectable saw or 
 Language: Pico SDK
 Creator: Adrian Vos
 Version: "0.9.3"
-Status: Stable
+Status: Beta - stable in single-developer testing
 date-created: 2026-06-21
 date-updated: 2026-07-13
 panel:
@@ -173,5 +173,5 @@ metadata:
   creator: Adrian Vos
   language: Pico SDK
   version: 0.9.3
-  status: Stable
+  status: Beta - stable in single-developer testing
   editor_url: https://tomwhitwell.github.io/Workshop_Computer/programs/87-fr330hfr33/web/index.html

--- a/releases/93_Turing_Matrix/info.yaml
+++ b/releases/93_Turing_Matrix/info.yaml
@@ -1,9 +1,13 @@
 id: 93_Turing_Matrix
-title: Turing Matrix
+Name: Turing Matrix
 draft: false
 release: 93 / 0.1.0-beta
 summary: Turing Machine sequencer with a switchable mixer layer inspired by the Music Thing Modular Turing Machine and Vactrol Mix combination
 short-description: Turing Machine sequencer with a switchable mixer layer inspired by the Music Thing Modular Turing Machine and Vactrol Mix combination
+Language: C++ (ComputerCard)
+Creator: Adrian Vos
+Version: "0.1.0-beta"
+Status: Beta release candidate
 date-created: 2026-06-26
 date-updated: 2026-07-13
 panel:
@@ -134,7 +138,7 @@ readme_url: >-
 download_url: >-
   https://raw.githubusercontent.com/TomWhitwell/Workshop_Computer/main/releases/93_Turing_Matrix/uf2/TuringMatrix.uf2
 metadata:
-  creator: Adrian Vos from initial code by Tom Whitwell / Music Thing Modular / Chris Johnson
+  creator: Adrian Vos
   language: C++ (ComputerCard)
   version: 0.1.0-beta
   status: Beta release candidate

--- a/releases/93_Turing_Matrix/info.yaml
+++ b/releases/93_Turing_Matrix/info.yaml
@@ -7,7 +7,7 @@ short-description: Turing Machine sequencer with a switchable mixer layer inspir
 Language: C++ (ComputerCard)
 Creator: Adrian Vos
 Version: "0.1.0-beta"
-Status: Beta release candidate
+Status: Beta - stable in single-developer testing
 date-created: 2026-06-26
 date-updated: 2026-07-13
 panel:
@@ -141,7 +141,7 @@ metadata:
   creator: Adrian Vos
   language: C++ (ComputerCard)
   version: 0.1.0-beta
-  status: Beta release candidate
+  status: Beta - stable in single-developer testing
   editor_url: https://tomwhitwell.github.io/Workshop_Computer/programs/93-turing-matrix/web/index.html
   editor_note: Configure this card in your browser
 documentation:


### PR DESCRIPTION
## Summary

Updates metadata and attribution across Adrian Vos program cards.

- Adds the current required top-level `info.yaml` fields where they were missing, so changed card metadata validates with zero errors.
- Standardises Creator attribution to `Adrian Vos`.
- Keeps prior implementation provenance in README attribution rather than the Creator field.
- Adds concise README credits for the ComputerCard framework, rppicomidi USB MIDI-host support, and the Dattorro/el-visio reverb implementation where applicable.
- Updates 21 documentation/metadata files across 11 card folders; no firmware, UF2, or DSP behaviour changes.

## Validation

- `tools/sitegen/src/validate/cli.js`: 0 blocking errors across all changed `info.yaml` files.
- Legacy-format warnings remain for existing generated/legacy metadata shapes.
- `git diff --check` passes.