### PR TITLE
fix: Simplify validation report retrieval in fork PR workflow

### DIFF
--- a/.github/workflows/report-fork-validation.yml
+++ b/.github/workflows/report-fork-validation.yml
@@ -15,14 +15,14 @@ permissions:
 jobs:
   report:
     name: Post validation report on fork PR
-    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.head_repository.full_name != github.repository && github.event.workflow_run.pull_requests[0]
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.head_repository.full_name != github.repository
     runs-on: ubuntu-latest
     steps:
       # This privileged workflow never checks out or executes code from the PR.
       - name: Download validation report
         uses: actions/download-artifact@v5
         with:
-          name: validation-report-${{ github.event.workflow_run.pull_requests[0].number }}
+          pattern: validation-report-*
           path: validation-report
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
@@ -30,16 +30,19 @@ jobs:
       - name: Post validation report on PR
         uses: actions/github-script@v8
         env:
-          REPORT_FILE: validation-report/validation-comment.md
-          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          REPORT_DIR: validation-report
         with:
           script: |
             const fs = require('fs');
+            const artifact = fs.readdirSync(process.env.REPORT_DIR)
+              .find(name => /^validation-report-\d+$/.test(name));
+            if (!artifact) throw new Error('Validation report artifact was not found');
+            const issue_number = Number(artifact.slice('validation-report-'.length));
+            const reportFile = `${process.env.REPORT_DIR}/${artifact}/validation-comment.md`;
             const marker = '<!-- workshop-computer-info-yaml-validation -->';
-            const report = fs.readFileSync(process.env.REPORT_FILE, 'utf8');
+            const report = fs.readFileSync(reportFile, 'utf8');
             const body = `${marker}\n${report}`;
             const { owner, repo } = context.repo;
-            const issue_number = Number(process.env.PR_NUMBER);
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner, repo, issue_number, per_page: 100,
             });


### PR DESCRIPTION
This pull request updates the workflow for posting validation reports on forked pull requests. The main focus is on improving the robustness of artifact handling and PR number extraction in the workflow, making it more flexible and less dependent on assumptions about the event payload.

**Workflow robustness and flexibility improvements:**

* The workflow no longer assumes the presence of a `pull_requests` array in the event payload, making it more reliable for forked PRs.
* Artifact download now uses a pattern (`validation-report-*`) to match any validation report artifact, instead of relying on a specific PR number.
* The PR number is dynamically extracted from the artifact name, ensuring the correct association even if the event payload structure changes.
* The path to the validation report file is constructed based on the discovered artifact, improving compatibility with the artifact structure.