### PR TITLE
feat: enhance PR validation to support flair synchronization compact edit list

### DIFF
--- a/.github/workflows/validate-info.yml
+++ b/.github/workflows/validate-info.yml
@@ -7,6 +7,7 @@ on:
       - workshop-ops
     paths:
       - 'releases/**'
+      - 'tools/sitegen/src/curation/flairs.yml'
 
 permissions:
   contents: read

--- a/tools/sitegen/src/validate/prRules.js
+++ b/tools/sitegen/src/validate/prRules.js
@@ -5,6 +5,7 @@
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
+import { isDeepStrictEqual } from 'node:util';
 import YAML from 'yaml';
 import { discoverCustomPanels, validateCustomPanelReferences } from '../discover/customPanels.js';
 
@@ -23,19 +24,56 @@ function diagnostic(severity, ruleId, file, message) {
 export function summarizePrTrigger(changes) {
   const affectedReleases = new Set();
   const changedPaths = [];
+  const directoryChanges = new Map();
+  const addChangedPath = (status, file) => {
+    const normalized = posix(file);
+    const release = releaseFromPath(normalized);
+    if (!release || normalized === `releases/${release}/info.yaml`) {
+      changedPaths.push({ status, path: normalized });
+      return;
+    }
+    const directory = `${path.posix.dirname(normalized)}/`;
+    const normalizedStatus = status[0];
+    directoryChanges.set(`${normalizedStatus}\0${directory}`, {
+      status: normalizedStatus, path: directory, filesUnder: true,
+    });
+  };
   for (const change of changes) {
     const paths = change.oldPath ? [change.oldPath, change.path] : [change.path];
     for (const file of paths) {
       const release = releaseFromPath(file);
       if (release) affectedReleases.add(release);
     }
-    changedPaths.push({
-      status: change.status,
-      ...(change.oldPath ? { oldPath: posix(change.oldPath) } : {}),
-      path: posix(change.path),
-    });
+    if (change.oldPath) {
+      addChangedPath('D', change.oldPath);
+      addChangedPath('A', change.path);
+    } else {
+      addChangedPath(change.status, change.path);
+    }
   }
+  changedPaths.push(...directoryChanges.values());
   return { affectedReleases: [...affectedReleases].sort(), changedPaths };
+}
+
+function allowsSynchronizedFlairs(changes, currentFlairs, baseFlairs) {
+  if (!currentFlairs || !baseFlairs) return false;
+  const addedCards = new Set(changes
+    .filter(change => change.status.startsWith('A'))
+    .map(change => posix(change.path).match(/^releases\/([^/]+)\/info\.yaml$/)?.[1])
+    .filter(Boolean));
+  const currentAssignments = currentFlairs.assignments;
+  const baseAssignments = baseFlairs.assignments;
+  if (!currentAssignments || typeof currentAssignments !== 'object' || Array.isArray(currentAssignments)
+      || !baseAssignments || typeof baseAssignments !== 'object' || Array.isArray(baseAssignments)) return false;
+  const withoutAssignments = value => Object.fromEntries(Object.entries(value).filter(([key]) => key !== 'assignments'));
+  if (!isDeepStrictEqual(withoutAssignments(currentFlairs), withoutAssignments(baseFlairs))) return false;
+  for (const [card, assignment] of Object.entries(baseAssignments)) {
+    if (!Object.hasOwn(currentAssignments, card) || !isDeepStrictEqual(currentAssignments[card], assignment)) return false;
+  }
+  const additions = Object.entries(currentAssignments).filter(([card]) => !Object.hasOwn(baseAssignments, card));
+  return additions.length > 0 && additions.every(([card, assignment]) =>
+    addedCards.has(card) && Array.isArray(assignment) && assignment.length === 0
+  );
 }
 
 function walkFiles(dir) {
@@ -134,7 +172,7 @@ function customBoardHasXosc64(cmakeSource, releaseFiles) {
  * Evaluate PR policy over parsed Git changes.
  * Change shape: { status, oldPath?, path }. `path` is the final/destination path.
  */
-export async function evaluatePrRules(changes, { root }) {
+export async function evaluatePrRules(changes, { root, baseFlairs = null }) {
   const diagnostics = [];
   const endpoints = [];
   for (const change of changes) {
@@ -148,9 +186,19 @@ export async function evaluatePrRules(changes, { root }) {
       `Changes affect ${releases.length} release directories: ${releases.join(', ')}.`));
   }
 
+  const flairsPath = 'tools/sitegen/src/curation/flairs.yml';
+  const flairsChanged = endpoints.map(posix).includes(flairsPath);
+  let synchronizedFlairs = false;
+  if (flairsChanged) {
+    try {
+      const currentFlairs = YAML.parse(fs.readFileSync(path.join(root, flairsPath), 'utf8')) || {};
+      synchronizedFlairs = allowsSynchronizedFlairs(changes, currentFlairs, baseFlairs);
+    } catch {}
+  }
   for (const file of [...new Set(endpoints.map(posix))].sort()) {
     const parts = file.split('/').filter(Boolean);
     if (parts[0] !== 'releases') {
+      if (file === flairsPath && synchronizedFlairs) continue;
       diagnostics.push(diagnostic('warning', 'change-outside-release-directory', file,
         'Card submissions must not include changes outside releases/<card>/ directories.'));
     } else if (parts.length < 3) {

--- a/tools/sitegen/src/validate/prRulesCli.js
+++ b/tools/sitegen/src/validate/prRulesCli.js
@@ -3,7 +3,9 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import YAML from 'yaml';
 import { evaluatePrRules, parseNameStatusZ, summarizePrTrigger } from './prRules.js';
 
 const output = process.argv[2];
@@ -14,7 +16,19 @@ if (!output) {
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
 const input = fs.readFileSync(0);
 const changes = parseNameStatusZ(input);
-const diagnostics = await evaluatePrRules(changes, { root });
+let baseFlairs = null;
+if (process.env.BASE_SHA && changes.some(change =>
+  change.path === 'tools/sitegen/src/curation/flairs.yml'
+  || change.oldPath === 'tools/sitegen/src/curation/flairs.yml'
+)) {
+  try {
+    const source = execFileSync('git', [
+      'show', `${process.env.BASE_SHA}:tools/sitegen/src/curation/flairs.yml`,
+    ], { cwd: root, encoding: 'utf8' });
+    baseFlairs = YAML.parse(source) || {};
+  } catch {}
+}
+const diagnostics = await evaluatePrRules(changes, { root, baseFlairs });
 const trigger = summarizePrTrigger(changes);
 const errorCount = diagnostics.filter(item => item.severity === 'error').length;
 const warningCount = diagnostics.filter(item => item.severity === 'warning').length;

--- a/tools/sitegen/src/validate/reporters/index.js
+++ b/tools/sitegen/src/validate/reporters/index.js
@@ -113,7 +113,9 @@ export function reportMarkdown(results, otherRules = null) {
   if (trigger?.changedPaths?.length) {
     lines.push('**Triggered by:**', '');
     for (const change of trigger.changedPaths) {
-      const label = change.oldPath
+      const label = change.filesUnder
+        ? `${change.status} files under ${change.path}`
+        : change.oldPath
         ? `${change.status} ${change.oldPath} → ${change.path}`
         : `${change.status} ${change.path}`;
       lines.push(`- ${code(label)}`);

--- a/tools/sitegen/test/pr-rules.test.js
+++ b/tools/sitegen/test/pr-rules.test.js
@@ -104,8 +104,65 @@ test('NUL name-status parsing preserves renames and spaces', () => {
   ]);
   assert.deepEqual(summarizePrTrigger(parsed), {
     affectedReleases: ['04 card'],
-    changedPaths: parsed,
+    changedPaths: [
+      { status: 'M', path: 'releases/04 card/info.yaml' },
+      { status: 'D', path: 'old/file.uf2' },
+      { status: 'A', path: 'releases/04 card/', filesUnder: true },
+    ],
   });
+});
+
+test('PR trigger keeps metadata and outside files but condenses release files by directory', () => {
+  assert.deepEqual(summarizePrTrigger([
+    { status: 'M', path: 'releases/42_card/info.yaml' },
+    { status: 'A', path: 'releases/42_card/firmware/card.uf2' },
+    { status: 'A', path: 'releases/42_card/firmware/source.elf' },
+    { status: 'D', path: 'releases/42_card/firmware/old.uf2' },
+    { status: 'M', path: 'documentation/info.yaml.md' },
+  ]), {
+    affectedReleases: ['42_card'],
+    changedPaths: [
+      { status: 'M', path: 'releases/42_card/info.yaml' },
+      { status: 'M', path: 'documentation/info.yaml.md' },
+      { status: 'A', path: 'releases/42_card/firmware/', filesUnder: true },
+      { status: 'D', path: 'releases/42_card/firmware/', filesUnder: true },
+    ],
+  });
+});
+
+test('sync-curation additions for newly added cards are the only allowed flair change', async t => {
+  const root = await fixture(t);
+  await write(root, 'releases/42_card/info.yaml', 'Name: Card');
+  await write(root, 'releases/42_card/README.md', '# Card');
+  await write(root, 'releases/42_card/card.uf2', 'firmware');
+  const baseFlairs = { available_flairs: [{ id: 'new' }], assignments: { '03_old': ['new'] } };
+  await write(root, 'tools/sitegen/src/curation/flairs.yml', `
+available_flairs:
+  - id: new
+assignments:
+  03_old: [new]
+  42_card: []
+`);
+  const changes = [
+    { status: 'A', path: 'releases/42_card/info.yaml' },
+    { status: 'M', path: 'tools/sitegen/src/curation/flairs.yml' },
+  ];
+  const allowed = await evaluatePrRules(changes, { root, baseFlairs });
+  assert.ok(!allowed.some(item =>
+    item.ruleId === 'change-outside-release-directory'
+    && item.file === 'tools/sitegen/src/curation/flairs.yml'));
+
+  await write(root, 'tools/sitegen/src/curation/flairs.yml', `
+available_flairs:
+  - id: new
+assignments:
+  03_old: []
+  42_card: []
+`);
+  const changedExisting = await evaluatePrRules(changes, { root, baseFlairs });
+  assert.ok(changedExisting.some(item =>
+    item.ruleId === 'change-outside-release-directory'
+    && item.file === 'tools/sitegen/src/curation/flairs.yml'));
 });
 
 test('deleting a complete release reports an explicit warning', async t => {

--- a/tools/sitegen/test/validate.test.js
+++ b/tools/sitegen/test/validate.test.js
@@ -77,6 +77,7 @@ test('PR Markdown report groups diagnostics by changed info.yaml', () => {
       changedPaths: [
         { status: 'M', path: 'releases/42_test/info.yaml' },
         { status: 'A', path: 'releases/43_clean/info.yaml' },
+        { status: 'A', path: 'releases/43_clean/firmware/', filesUnder: true },
       ],
     },
     diagnostics: [
@@ -93,6 +94,7 @@ test('PR Markdown report groups diagnostics by changed info.yaml', () => {
   assert.match(markdown, /## Other rules/);
   assert.match(markdown, /\*\*Triggered by:\*\*/);
   assert.match(markdown, /`M releases\/42_test\/info.yaml`/);
+  assert.match(markdown, /`A files under releases\/43_clean\/firmware\/`/);
   assert.match(markdown, /\*\*Affected release directories:\*\* `42_test`, `43_clean`/);
   assert.ok(markdown.indexOf('**Triggered by:**') < markdown.indexOf('### `42_test/info.yaml`'));
   assert.ok(markdown.indexOf('**Triggered by:**') < markdown.indexOf('## Other rules'));


### PR DESCRIPTION
This pull request enhances the PR validation workflow and logic for the repository, focusing on more accurate change summarization and introducing a special exception for synchronized flair assignments when adding new cards. The main improvements include condensing directory-level changes in release folders, allowing certain automated flair changes, and updating tests and reporting to reflect these behaviors.

**Change summarization and reporting improvements:**

* The `summarizePrTrigger` function now condenses changes under `releases/<card>/` directories into directory-level entries (e.g., "A files under releases/42_card/firmware/"), making the PR trigger summary more concise and readable. [[1]](diffhunk://#diff-c039c90e9f2e36b6d1de749b6c50926dba08a1c77cbca1d61f445f8fef810118R27-R78) [[2]](diffhunk://#diff-43d126b13aa3a49e047120f3e66934a1928071ca030f231c5c8a72793cdae621L116-R118)
* The markdown reporter and related tests are updated to display these condensed directory-level changes, improving clarity in PR feedback. [[1]](diffhunk://#diff-43d126b13aa3a49e047120f3e66934a1928071ca030f231c5c8a72793cdae621L116-R118) [[2]](diffhunk://#diff-609617b01b137c0e1d9f3c6ca9b25123f81a5c370c353170bf281b5cc6b10c59R80) [[3]](diffhunk://#diff-609617b01b137c0e1d9f3c6ca9b25123f81a5c370c353170bf281b5cc6b10c59R97) [[4]](diffhunk://#diff-8df54643cb5ec191f658721f61fa2efddb09e4f1f46ff490a265d044556c2d8fL107-R165)

**Flair assignment synchronization exception:**

* Adds logic to allow PRs that add new cards to also add empty flair assignments for those cards in `flairs.yml`, provided no other flair changes are made. This is enforced via the new `allowsSynchronizedFlairs` function and supporting logic in `evaluatePrRules`. [[1]](diffhunk://#diff-c039c90e9f2e36b6d1de749b6c50926dba08a1c77cbca1d61f445f8fef810118R27-R78) [[2]](diffhunk://#diff-c039c90e9f2e36b6d1de749b6c50926dba08a1c77cbca1d61f445f8fef810118L137-R175) [[3]](diffhunk://#diff-c039c90e9f2e36b6d1de749b6c50926dba08a1c77cbca1d61f445f8fef810118R189-R201)
* The CLI and workflow are updated to load the base version of `flairs.yml` for comparison, enabling this exception to be checked accurately. [[1]](diffhunk://#diff-de3c2c5e08ecb0fa48628092cecb9ff7f184c83ffbcd77ab2372a15fe8ada4c2R6-R8) [[2]](diffhunk://#diff-de3c2c5e08ecb0fa48628092cecb9ff7f184c83ffbcd77ab2372a15fe8ada4c2L17-R31)
* The validation workflow is triggered on changes to `flairs.yml` as well as release files. (.github/workflows/validate-info.yml)

**Test coverage:**

* New and updated tests verify that directory-level change condensation and the flair synchronization exception behave as intended.

These changes streamline PR validation, reduce noise in change summaries, and support a smoother workflow for adding new cards with synchronized flair assignments.