### PR TITLE
External-link arrows as SVG, and mobile tag-filter fixes

### DIFF
--- a/tools/sitegen/assets/preview/author-client.js
+++ b/tools/sitegen/assets/preview/author-client.js
@@ -5,6 +5,7 @@ import { buildCanonicalCardModel } from './lib/model/card.js';
 import { renderCardArticle } from './lib/render/cardPage.js';
 import { renderReadmeAndDocs } from './lib/render/cardPage.js';
 import { panelPositions } from './lib/render/panelPositions.js';
+import { externalLinkArrow } from './lib/render/icons.js';
 import { resolveAudioSamples, getAudioField } from './lib/utils/audio.js';
 import { getInfoYamlSchemaAdapter } from './lib/schema/schemaAdapter.js';
 import { arrayOrEmpty } from './lib/utils/strings.js';
@@ -1079,9 +1080,9 @@ function licenseFileGuidance(id) {
   };
   const item = guidance[id];
   if (!item) {
-    return `<div class="author-license-file-guidance"><strong>Include the license file</strong><p>Add the complete authoritative license text as <code>LICENSE</code> beside <code>info.yaml</code>, and preserve all third-party notices.</p><a href="https://choosealicense.com/licenses/" target="_blank" rel="noopener noreferrer">Find official license text ↗</a></div>`;
+    return `<div class="author-license-file-guidance"><strong>Include the license file</strong><p>Add the complete authoritative license text as <code>LICENSE</code> beside <code>info.yaml</code>, and preserve all third-party notices.</p><a href="https://choosealicense.com/licenses/" target="_blank" rel="noopener noreferrer">Find official license text${externalLinkArrow()}</a></div>`;
   }
-  return `<div class="author-license-file-guidance"><strong>Include the license file</strong><p>${escapeHtml(item.text)}</p><a href="${item.url}" target="_blank" rel="noopener noreferrer">Get the ${escapeHtml(id)} license text ↗</a></div>`;
+  return `<div class="author-license-file-guidance"><strong>Include the license file</strong><p>${escapeHtml(item.text)}</p><a href="${item.url}" target="_blank" rel="noopener noreferrer">Get the ${escapeHtml(id)} license text${externalLinkArrow()}</a></div>`;
 }
 
 function chooseLicense(id, explanation, { manual = false, provisional = false } = {}) {

--- a/tools/sitegen/assets/style.css
+++ b/tools/sitegen/assets/style.css
@@ -28,6 +28,9 @@
 
 * { box-sizing: border-box; }
 .sr-only { clip: rect(0, 0, 0, 0); clip-path: inset(50%); height: 1px; overflow: hidden; position: absolute; white-space: nowrap; width: 1px; }
+/* Decorative "leaves the site" marker; scales with the surrounding text. The
+   margin stands in for the space that used to precede the old arrow glyph. */
+.external-link-arrow { display: inline-block; height: 0.72em; margin-left: 0.3em; vertical-align: baseline; width: 0.72em; }
 html, body { background: var(--bg); color: var(--text); font: var(--weight-normal) 18px/1.5 "Inter", "Helvetica Neue", Helvetica, Arial, sans-serif; margin: 0; padding: 0; }
 .container { margin: 0 auto; max-width: 900px; padding-left: 30px; padding-right: 30px; }
 main.container { padding-top: 30px; }
@@ -90,7 +93,9 @@ a { color: var(--link); }
 /* Filter tags are .program-card-tag badges, so appearance comes from program-cards.css;
    these rules add only the checkbox affordances. */
 .tag-filter-option { cursor: pointer; transition: box-shadow .15s,filter .15s; }
-.tag-filter-option[hidden] { display: none; }
+/* Specificity must beat the narrow-viewport .filter-bar .tag-filter-option rule
+   below, or the hidden attribute stops hiding tags on mobile. */
+.filter-bar .tag-filter-option[hidden] { display: none; }
 .tag-filter-option:has(input:focus-visible) { outline: 2px solid var(--text); outline-offset: 2px; }
 .tag-filter-option:has(input:checked) { box-shadow: 0 0 0 2px var(--bg), 0 0 0 4px var(--text); }
 .tag-filter-option input { height: 1px; opacity: 0; position: absolute; width: 1px; }

--- a/tools/sitegen/src/build.js
+++ b/tools/sitegen/src/build.js
@@ -11,6 +11,7 @@ import { infoYamlJsonSchema } from './schema/infoYamlJsonSchema.js';
 import { renderCardArticle, renderReadmeAndDocs } from './render/cardPage.js';
 import { renderDiscovery, renderArchive, renderArchiveRows } from './render/discovery.js';
 import { renderFilterBar } from './render/filterBar.js';
+import { externalLinkArrow } from './render/icons.js';
 import { curation } from './curation/index.js';
 import { parseSource } from './validate/parseSource.js';
 import { validateInfoYaml } from './validate/validateInfoYaml.js';
@@ -90,7 +91,7 @@ function detailPage(rel) {
     content: `
 <nav class="program-card-top-nav" aria-label="Card navigation">
   <a href="../../index.html">← BACK TO PROGRAM CARDS</a>
-  <a class="program-card-author-link" href="../../preview/#${encodeURIComponent(rel.slug)}">Author Metadata ↗</a>
+  <a class="program-card-author-link" href="../../preview/#${encodeURIComponent(rel.slug)}">Author Metadata${externalLinkArrow()}</a>
 </nav>
 ${article}
 <nav class="program-card-top-nav program-card-top-nav--footer" aria-label="Card navigation">
@@ -379,8 +380,8 @@ ${renderFilterBar({ creatorOptions, sortOptions, tagOptions, linkHref: 'archive/
     <h1>All cards</h1>
     <nav class="program-cards__links" aria-label="Program card links">
       <a href="../index.html">Program cards home</a>
-      <a href="https://www.musicthing.co.uk/workshopsystem/program-cards/install/" target="_blank" rel="noopener noreferrer">Installation <span aria-hidden="true">↗</span><span class="sr-only"> (opens in a new tab)</span></a>
-      <a href="https://github.com/${REPO}" target="_blank" rel="noopener noreferrer">Make a card <span aria-hidden="true">↗</span><span class="sr-only"> (opens in a new tab)</span></a>
+      <a href="https://www.musicthing.co.uk/workshopsystem/program-cards/install/" target="_blank" rel="noopener noreferrer">Installation${externalLinkArrow()}<span class="sr-only"> (opens in a new tab)</span></a>
+      <a href="https://github.com/${REPO}" target="_blank" rel="noopener noreferrer">Make a card${externalLinkArrow()}<span class="sr-only"> (opens in a new tab)</span></a>
     </nav>
   </header>
   ${renderFilterBar({ creatorOptions, sortOptions, tagOptions, linkHref: '../index.html', linkText: 'Program cards home', label: 'Search cards' })}
@@ -488,6 +489,7 @@ const PREVIEW_LIB_FILES = [
   'validate/rules/index.js',
   'model/card.js',
   'render/panelPositions.js',
+  'render/icons.js',
   'render/cardPage.js',
 ];
 

--- a/tools/sitegen/src/render/authorPage.js
+++ b/tools/sitegen/src/render/authorPage.js
@@ -1,6 +1,7 @@
 // Unified visual/YAML author page for new and existing cards.
 
 import { applyContentSecurityPolicy, CSP_PLACEHOLDER } from './csp.js';
+import { externalLinkArrow } from './icons.js';
 
 export function renderAuthorPage({ documentKind = 'new', suggestions = {} } = {}) {
   const existing = documentKind === 'existing';
@@ -41,7 +42,7 @@ export function renderAuthorPage({ documentKind = 'new', suggestions = {} } = {}
       </div>
       <div class="author-toolbar__actions">
         <div class="author-toolbar__primary">
-          <label class="author-document-picker">Card <select id="card-select" aria-label="Card"><option value="new">＋ NEW</option></select></label>${existing ? '<a id="production-card-link" class="author-production-link" href="#" target="_blank" rel="noopener noreferrer">View card page ↗</a><span id="editor-status" class="author-progress" aria-live="polite"></span>' : '<a class="author-production-link" href="../index.html">Program cards home</a>'}
+          <label class="author-document-picker">Card <select id="card-select" aria-label="Card"><option value="new">＋ NEW</option></select></label>${existing ? `<a id="production-card-link" class="author-production-link" href="#" target="_blank" rel="noopener noreferrer">View card page${externalLinkArrow()}</a><span id="editor-status" class="author-progress" aria-live="polite"></span>` : '<a class="author-production-link" href="../index.html">Program cards home</a>'}
           <span id="required-progress" class="author-progress" aria-live="polite"></span>
           <div class="author-mode-switch" role="group" aria-label="Editing mode">
             <button type="button"${existing ? ' disabled title="Basic availability is checked after the card loads"' : ' class="is-active"'} data-mode="author" aria-pressed="${existing ? 'false' : 'true'}">Basic</button>
@@ -49,7 +50,7 @@ export function renderAuthorPage({ documentKind = 'new', suggestions = {} } = {}
           </div>
         </div>
         <div class="author-toolbar__downloads">
-          <a class="btn secondary" href="https://github.com/TomWhitwell/Workshop_Computer/blob/main/documentation/info.yaml.md" target="_blank" rel="noopener noreferrer">Schema documentation ↗</a>
+          <a class="btn secondary" href="https://github.com/TomWhitwell/Workshop_Computer/blob/main/documentation/info.yaml.md" target="_blank" rel="noopener noreferrer">Schema documentation${externalLinkArrow()}</a>
           <button id="download-source" class="btn download" type="button">Download info.yaml</button>
           <button id="download-panel-image" class="btn secondary" type="button">Download panel SVG</button>
           <button id="start-fresh" class="btn secondary" type="button">Start fresh</button>
@@ -66,8 +67,8 @@ export function renderAuthorPage({ documentKind = 'new', suggestions = {} } = {}
           <header><div><span class="author-step">Start here</span><h2>Card details</h2></div><span class="author-required-key">Required</span></header>
           <div class="author-form-grid">
             <label class="author-field author-field--wide"><span>Name <strong>Required</strong></span><input data-field="Name" required placeholder="Card display name"></label>
-            <label class="author-field author-field--wide"><span>Short description <strong>Required</strong> <small class="author-field-guidance">(used in card search and the all cards index; <a href="../archive/" target="_blank" rel="noopener noreferrer">see example ↗</a>)</small></span><textarea data-field="short-description" required rows="2" placeholder="A concise tagline for indexes, shelves, and archive rows"></textarea></label>
-            <label class="author-field author-field--wide"><span>Summary <strong>Required</strong> <small class="author-field-guidance">(used beneath the title on card pages; <a href="../programs/15-mlrws/" target="_blank" rel="noopener noreferrer">see example ↗</a>)</small></span><textarea data-field="summary" required rows="4" placeholder="A longer operator overview for the card detail page"></textarea><small>Markdown is supported, including links, emphasis, and inline code.</small></label>
+            <label class="author-field author-field--wide"><span>Short description <strong>Required</strong> <small class="author-field-guidance">(used in card search and the all cards index; <a href="../archive/" target="_blank" rel="noopener noreferrer">see example${externalLinkArrow()}</a>)</small></span><textarea data-field="short-description" required rows="2" placeholder="A concise tagline for indexes, shelves, and archive rows"></textarea></label>
+            <label class="author-field author-field--wide"><span>Summary <strong>Required</strong> <small class="author-field-guidance">(used beneath the title on card pages; <a href="../programs/15-mlrws/" target="_blank" rel="noopener noreferrer">see example${externalLinkArrow()}</a>)</small></span><textarea data-field="summary" required rows="4" placeholder="A longer operator overview for the card detail page"></textarea><small>Markdown is supported, including links, emphasis, and inline code.</small></label>
             <label class="author-field"><span>Creator <strong>Required</strong></span><input data-field="Creator" required list="creator-suggestions" placeholder="Your name or handle"></label>
             <label class="author-field"><span>Language <strong>Required</strong></span><input data-field="Language" required list="language-suggestions" placeholder="ie. Pico SDK"></label>
             <label class="author-field"><span>Version <strong>Required</strong></span><input data-field="Version" required placeholder="For example, 1.0.0"></label>
@@ -122,7 +123,7 @@ export function renderAuthorPage({ documentKind = 'new', suggestions = {} } = {}
   <dialog id="license-dialog" class="author-license-dialog" aria-labelledby="license-title">
     <form method="dialog">
       <header><div><span class="author-step">License assistant</span><h2 id="license-title">How may others use your work?</h2></div><button value="cancel" aria-label="Close">×</button></header>
-      <p class="author-legal-note">This assistant explains common choices and records your selection. It is not legal advice. Confirm that third-party code and assets are compatible. For more guidance, visit <a href="https://choosealicense.com/" target="_blank" rel="noopener noreferrer">Choose a License ↗</a>.</p>
+      <p class="author-legal-note">This assistant explains common choices and records your selection. It is not legal advice. Confirm that third-party code and assets are compatible. For more guidance, visit <a href="https://choosealicense.com/" target="_blank" rel="noopener noreferrer">Choose a License${externalLinkArrow()}</a>.</p>
       <div class="author-license-boundary author-license-boundary--legal"><strong>Legal license</strong><span>The choices in this section determine the legal permissions and obligations attached to the source code.</span></div>
       <div class="author-license-quick">
         <h3>Choose a legal license directly</h3>

--- a/tools/sitegen/src/render/cardPage.js
+++ b/tools/sitegen/src/render/cardPage.js
@@ -8,6 +8,7 @@
 
 import { panelPositions } from './panelPositions.js';
 import { renderMarkdownBlock, renderMarkdownInline, sanitizeAuthoredHtml } from '../utils/markdown.js';
+import { externalLinkArrow } from './icons.js';
 
 const DEFAULT_DISCUSSION = 'https://discord.com/channels/1210238368898879569/1484219323039092938';
 
@@ -344,7 +345,7 @@ function renderAudio(samples) {
       const height = s.height || (s.kind === 'soundcloud' ? 166 : 120);
       return `<div class="program-card-audio__item">${title}<iframe class="program-card-audio__embed program-card-audio__embed--${esc(s.kind)}" src="${esc(s.embedUrl)}" width="100%" height="${height}" loading="lazy" frameborder="0" allow="autoplay" title="${esc(s.title || (s.kind + ' player'))}"></iframe></div>`;
     }
-    return `<div class="program-card-audio__item">${title}<a class="program-card-audio__link" href="${esc(s.url)}" target="_blank" rel="noopener noreferrer">${esc(s.host || s.url)} ↗</a></div>`;
+    return `<div class="program-card-audio__item">${title}<a class="program-card-audio__link" href="${esc(s.url)}" target="_blank" rel="noopener noreferrer">${esc(s.host || s.url)}${externalLinkArrow()}</a></div>`;
   }).join('');
   return `<section class="program-card-audio"><h2>Audio samples</h2>${items}</section>`;
 }

--- a/tools/sitegen/src/render/discovery.js
+++ b/tools/sitegen/src/render/discovery.js
@@ -5,6 +5,7 @@
 // adapted to the canonical card model and the local curation layer.
 
 import { curation, resolveFlair } from '../curation/index.js';
+import { externalLinkArrow } from './icons.js';
 
 const CARD_ARTWORK = {
   '00_Simple_MIDI': '00-simple-midi.svg',
@@ -114,7 +115,7 @@ export function renderTile(card, opts = {}) {
       <span class="program-card-tile__head"><span class="program-card-tile__title">${artwork || `<span class="program-card-tile__number">${esc(number)}</span>`}<span class="program-card-tile__name">${esc(truncate(card.title || card.id || 'Untitled card', 48))}</span>${showCreator && metadata.creator ? `<span class="program-card-tile__byline">by ${esc(metadata.creator)}</span>` : ''}</span></span>
       ${!featuredCopy && summary ? `<span class="program-card-tile__summary">${esc(truncate(summary, 190))}</span>` : ''}
     </a>
-    ${featuredCopy ? `<span class="program-card-tile__summary">${esc(featuredCopy.text)}<a class="program-card-tile__inline-link" href="${esc(featuredCopy.link)}" target="_blank" rel="noopener noreferrer">${esc(featuredCopy.linkText)} <span aria-hidden="true">↗</span><span class="sr-only"> (opens in a new tab)</span></a></span>` : ''}
+    ${featuredCopy ? `<span class="program-card-tile__summary">${esc(featuredCopy.text)}<a class="program-card-tile__inline-link" href="${esc(featuredCopy.link)}" target="_blank" rel="noopener noreferrer">${esc(featuredCopy.linkText)}${externalLinkArrow()}<span class="sr-only"> (opens in a new tab)</span></a></span>` : ''}
     ${showAllTags ? renderAllTagBadges(card, flair, root) : renderFlairBadges(flair, hideFlairs, root)}
   </article>`;
 }

--- a/tools/sitegen/src/render/icons.js
+++ b/tools/sitegen/src/render/icons.js
@@ -1,0 +1,17 @@
+// Shared inline SVG icons.
+//
+// Kept as plain markup strings so they can be interpolated into the string
+// templates and copied verbatim into the preview tool's lib/ directory.
+
+/**
+ * Small north-east arrow used to mark links that leave the site.
+ * Decorative: callers pair it with an `.sr-only` "(opens in a new tab)" label
+ * where the destination is not otherwise obvious.
+ *
+ * Append it directly after the link text with no separating space - the gap
+ * comes from `.external-link-arrow`'s margin, so the arrow can never wrap onto
+ * a line of its own.
+ */
+export function externalLinkArrow() {
+  return '<svg class="external-link-arrow" viewBox="0 0 10 10" width="10" height="10" aria-hidden="true" focusable="false"><path d="M1.2 8.8 7.4 2.6M3.4 2.3h4.3v4.3" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="butt" stroke-linejoin="miter"/></svg>';
+}

--- a/tools/sitegen/src/render/layout.js
+++ b/tools/sitegen/src/render/layout.js
@@ -1,4 +1,5 @@
 import { applyContentSecurityPolicy, CSP_PLACEHOLDER } from './csp.js';
+import { externalLinkArrow } from './icons.js';
 
 export function renderLayout({ title, content, relativeRoot = '.', legacyRedirectRoot = relativeRoot, repoUrl = 'https://github.com/TomWhitwell/Workshop_Computer', showProgramIdentity = false }) {
   const html = `<!doctype html>
@@ -36,8 +37,8 @@ export function renderLayout({ title, content, relativeRoot = '.', legacyRedirec
         <span class="program-cards__identity-name">Program Cards</span>
       </a>
       <nav class="program-cards__links" aria-label="Program card links">
-        <a href="https://www.musicthing.co.uk/workshopsystem/program-cards/install/" target="_blank" rel="noopener noreferrer">Installation <span aria-hidden="true">↗</span><span class="sr-only"> (opens in a new tab)</span></a>
-        <a href="${repoUrl}" target="_blank" rel="noopener noreferrer">Make a card <span aria-hidden="true">↗</span><span class="sr-only"> (opens in a new tab)</span></a>
+        <a href="https://www.musicthing.co.uk/workshopsystem/program-cards/install/" target="_blank" rel="noopener noreferrer">Installation${externalLinkArrow()}<span class="sr-only"> (opens in a new tab)</span></a>
+        <a href="${repoUrl}" target="_blank" rel="noopener noreferrer">Make a card${externalLinkArrow()}<span class="sr-only"> (opens in a new tab)</span></a>
       </nav>
     </header>` : ''}
     ${content}

--- a/tools/sitegen/test/render.test.js
+++ b/tools/sitegen/test/render.test.js
@@ -185,8 +185,8 @@ test('advanced author editor includes highlighting, diagnostics, and YAML format
 
 test('basic author fields link to new-tab examples of their published usage', () => {
   const preview = renderAuthorPage();
-  assert.match(preview, /Short description[\s\S]*class="author-field-guidance">\(used in card search and the all cards index; <a href="\.\.\/archive\/" target="_blank" rel="noopener noreferrer">see example ↗<\/a>/);
-  assert.match(preview, /Summary[\s\S]*used beneath the title on card pages; <a href="\.\.\/programs\/15-mlrws\/" target="_blank" rel="noopener noreferrer">see example ↗<\/a>/);
+  assert.match(preview, /Short description[\s\S]*class="author-field-guidance">\(used in card search and the all cards index; <a href="\.\.\/archive\/" target="_blank" rel="noopener noreferrer">see example<svg class="external-link-arrow"[\s\S]*?<\/svg><\/a>/);
+  assert.match(preview, /Summary[\s\S]*used beneath the title on card pages; <a href="\.\.\/programs\/15-mlrws\/" target="_blank" rel="noopener noreferrer">see example<svg class="external-link-arrow"[\s\S]*?<\/svg><\/a>/);
 });
 
 test('basic author mode exposes live-preview web editor metadata', () => {


### PR DESCRIPTION
- Replace the text external-site arrow with an inline SVG icon (new tools/sitegen/src/render/icons.js, used by layout, card, discovery and author pages).
- Fix the tag filter on narrow viewports: the max-width:700px `.filter-bar .tag-filter-option` rule outranked `.tag-filter-option[hidden]`, so every tag stayed visible and the "Show all…/Show fewer…" toggle appeared to do nothing.