### PR TITLE
Fix sorting of cards without authored dates

### DIFF
--- a/tools/sitegen/src/model/card.js
+++ b/tools/sitegen/src/model/card.js
@@ -552,12 +552,14 @@ export function buildCanonicalCardModel({
     warnings,
     'date-created',
   );
+  let createdInferred = false;
   if (!created) {
     // Earliest genesis signal: the folder's first commit and Phil's oldest
     // blame date are both "early" markers (and use different date sources), so
     // take whichever is earlier. This also keeps `created` <= derived `updated`.
     const early = [gitFirstDate, blameDate].filter(Boolean).sort();
     created = early[0] || '';
+    createdInferred = Boolean(created);
   }
   if (!created) created = 'n/a';
   let updated = normalizedDate(field(info, 'date-updated', 'updated', 'updated_at'), warnings, 'date-updated');
@@ -615,6 +617,7 @@ export function buildCanonicalCardModel({
     discussion_url: optionalText(field(info, 'discussion'), warnings, 'discussion'),
     contact: sanitizeValue(field(info, 'contact')),
   };
+  if (createdInferred) metadata.created_inferred = true;
   if (editor) {
     metadata.editor_url = editor;
     metadata.editor_note = 'Configure this card in your browser';

--- a/tools/sitegen/src/render/cardPage.js
+++ b/tools/sitegen/src/render/cardPage.js
@@ -452,7 +452,7 @@ export function renderCardArticle({ card, panelImg, yamlUrl, uf2Url, extraDocs =
       ${metadata.version ? `<div><dt>Version</dt><dd>${esc(metadata.version)}</dd></div>` : ''}
       ${metadata.status ? `<div><dt>Status</dt><dd>${esc(metadata.status)}</dd></div>` : ''}
       ${metadata.license ? `<div><dt>License</dt><dd>${esc(metadata.license)}</dd></div>` : ''}
-      ${metadata.created && metadata.created !== 'n/a' ? `<div><dt>Created</dt><dd>${esc(metadata.created)}</dd></div>` : ''}
+      ${!metadata.created_inferred && metadata.created && metadata.created !== 'n/a' ? `<div><dt>Created</dt><dd>${esc(metadata.created)}</dd></div>` : ''}
       ${metadata.updated && metadata.updated !== 'n/a' ? `<div><dt>Updated</dt><dd>${esc(metadata.updated)}</dd></div>` : ''}
       ${card.memory && card.memory.size ? `<div><dt>Card memory</dt><dd>${esc(String(card.memory.size).toUpperCase())} ${esc(card.memory.requirement || 'supported')}</dd></div>` : ''}
       ${readmeUrl ? `<div><dt>Read more</dt><dd><a href="${esc(readmeUrl)}">README in the Workshop Computer repo</a></dd></div>` : ''}

--- a/tools/sitegen/src/render/discovery.js
+++ b/tools/sitegen/src/render/discovery.js
@@ -82,6 +82,7 @@ export function renderTile(card, opts = {}) {
   const number = cardNumber(card);
   const summary = card.short_description || '';
   const metadata = card.metadata || {};
+  const sortDate = metadata.created || '';
   const firstVideo = Array.isArray(card.videos) && card.videos[0];
   const featuredCopy = showArtwork ? FEATURED_COPY[card.id] : null;
 
@@ -107,7 +108,7 @@ export function renderTile(card, opts = {}) {
 
   return `<article class="program-card-tile${media ? ' program-card-tile--video' : ''}${artwork ? ' program-card-tile--artwork' : ''}"` +
     ` data-creator="${escapeAttr(metadata.creator || '')}" data-language="${escapeAttr(metadata.language || '')}"` +
-    ` data-type="${escapeAttr(metadata.status || '')}" data-date="${escapeAttr(metadata.created || '')}"` +
+    ` data-type="${escapeAttr(metadata.status || '')}" data-date="${escapeAttr(sortDate)}"` +
     ` data-name="${escapeAttr(String(card.title || card.id || '').toLowerCase())}" data-num="${escapeAttr(String(parseInt(number, 10) || 0))}"` +
     ` data-tags="${escapeAttr(tagFilter)}" data-search="${escapeAttr(searchText)}">
     <a class="program-card-tile__link" href="${card.id === '88_Blank' && showArtwork ? `${root}/random/` : `${root}/programs/${card.slug}/`}">

--- a/tools/sitegen/test/card.test.js
+++ b/tools/sitegen/test/card.test.js
@@ -44,6 +44,7 @@ test('created derives from the earliest git signal; updated from content date', 
     gitLastDate: '2025-05-01',
   });
   assert.equal(card.metadata.created, '2024-01-15');
+  assert.equal(card.metadata.created_inferred, true);
   assert.equal(card.metadata.updated, '2025-03-01');
 });
 
@@ -62,6 +63,7 @@ test('authored creation and update dates remain independent', () => {
     contentDate: '2026-01-01',
   });
   assert.equal(card.metadata.created, '2024-02-03');
+  assert.equal(card.metadata.created_inferred, undefined);
   assert.equal(card.metadata.updated, '2025-06-07');
 });
 

--- a/tools/sitegen/test/render.test.js
+++ b/tools/sitegen/test/render.test.js
@@ -111,6 +111,16 @@ test('card details render configured creation and update dates', () => {
   assert.match(html, /<dt>Updated<\/dt><dd>2025-06-07<\/dd>/);
 });
 
+test('card details hide inferred creation dates', () => {
+  const html = renderCardArticle({
+    card: card({ metadata: { created: '2024-02-03', created_inferred: true, updated: '2025-06-07' } }),
+    panelImg: 'panel.svg', yamlUrl: 'source.yaml',
+  });
+  assert.doesNotMatch(html, /<dt>Created<\/dt>/);
+  assert.doesNotMatch(html, /2024-02-03/);
+  assert.match(html, /<dt>Updated<\/dt><dd>2025-06-07<\/dd>/);
+});
+
 test('discovery renderers escape searchable attributes and ignore absent shelf cards', () => {
   const testCard = card({
     title: 'A "quoted" <card>', slug: 'safe-slug',
@@ -126,6 +136,14 @@ test('discovery renderers escape searchable attributes and ignore absent shelf c
   const shelf = renderShelf({ title: 'Shelf <One>', cards: ['missing', testCard.id] }, new Map([[testCard.id, testCard]]));
   assert.match(shelf, /Shelf &lt;One&gt;/);
   assert.equal((shelf.match(/program-card-tile__link/g) || []).length, 1);
+});
+
+test('catalogue sorting uses inferred creation dates', () => {
+  const inferred = card({
+    metadata: { created: '2026-07-29', created_inferred: true },
+  });
+  assert.match(renderTile(inferred), /data-date="2026-07-29"/);
+  assert.match(renderArchive([inferred]), /data-date="2026-07-29"/);
 });
 
 test('featured blank card overlays its label artwork on the randomized card icon', () => {


### PR DESCRIPTION
Fix #309: sort can use. inferred creation dates but card details never show the inferred value

This pull request improves how card creation dates are handled and displayed, especially when the creation date is inferred rather than explicitly authored. The main changes add a `created_inferred` flag to card metadata, ensure inferred creation dates are not shown in the UI, and update tests to cover these behaviors.

**Creation date inference and metadata:**
* Added a `created_inferred` boolean to card metadata when the creation date is derived from git/blame signals instead of being explicitly authored. [[1]](diffhunk://#diff-17ebee094b61473a73620f95c685157bb225dc1f4f51be788aa83c4c5348d825R555-R562) [[2]](diffhunk://#diff-17ebee094b61473a73620f95c685157bb225dc1f4f51be788aa83c4c5348d825R620)

**UI rendering logic:**
* Updated `renderCardArticle` to hide the "Created" field if the creation date is inferred, ensuring users only see authored creation dates.
* Updated `renderTile` and related catalogue sorting logic to use the inferred creation date for sorting and display, even if it's not shown in the details panel. [[1]](diffhunk://#diff-c116525a31614fcebe4cda98217c2837f723bf5dc89782eef528d308a70c3e76R85) [[2]](diffhunk://#diff-c116525a31614fcebe4cda98217c2837f723bf5dc89782eef528d308a70c3e76L110-R111)

**Testing:**
* Added and updated tests to verify that `created_inferred` is set correctly, that inferred creation dates are hidden in the details, and that catalogue sorting uses inferred dates. [[1]](diffhunk://#diff-5e7c6b4bd086336748f5c602f409eb0e2753565093a2706324e7ee513d9553d7R47) [[2]](diffhunk://#diff-5e7c6b4bd086336748f5c602f409eb0e2753565093a2706324e7ee513d9553d7R66) [[3]](diffhunk://#diff-0c0bfbe195088f186db854d35145fb8817a69e2ced82e739c38d2a4981700f5dR114-R123) [[4]](diffhunk://#diff-0c0bfbe195088f186db854d35145fb8817a69e2ced82e739c38d2a4981700f5dR141-R148)