### PR TITLE
Preserve unused jack positions in card details

### DIFF
--- a/tools/sitegen/assets/program-cards.css
+++ b/tools/sitegen/assets/program-cards.css
@@ -1143,6 +1143,15 @@ a.program-card-tag:visited {
   overflow: hidden;
 }
 
+.program-card-socket--empty {
+  color: var(--program-card-muted);
+  font-size: 0.82rem;
+  font-family: inherit;
+  font-style: normal;
+  grid-template-rows: 1fr;
+  place-items: center;
+}
+
 .program-card-socket .program-card-component-key {
   background: var(--program-card-soft);
   border-bottom: 1px solid var(--program-card-rule);
@@ -1442,6 +1451,10 @@ a.program-card-tag:visited {
 
   .program-card-socket-list {
     grid-template-columns: 1fr;
+  }
+
+  .program-card-socket--empty {
+    display: none;
   }
 
   .program-card-io-columns {

--- a/tools/sitegen/src/render/cardPage.js
+++ b/tools/sitegen/src/render/cardPage.js
@@ -250,13 +250,15 @@ function renderSocketList(title, sockets, positions) {
   if (!sockets) return '';
   const items = (positions || []).map(pos => {
     const socket = sockets[pos.key];
-    if (!socket || (!socket.description && !socket.label)) return '';
+    if (!socket || (!socket.description && !socket.label)) {
+      return '<div class="program-card-socket program-card-socket--empty" aria-hidden="true"><span>Unused</span></div>';
+    }
     return `<div class="program-card-socket">
       <strong class="program-card-component-key">${esc(pos.name || pos.key)}</strong>
       ${socket.label || socket.description ? `<p>${socket.label ? `<span class="program-card-component-role">${esc(inline(socket.label))}</span>` : ''}${socket.label && socket.description ? '<br>' : ''}${socket.description ? esc(truncate(socket.description, 220)) : ''}</p>` : ''}
     </div>`;
   }).join('');
-  if (!items.trim()) return '';
+  if (!Object.values(sockets).some(socket => socket && (socket.description || socket.label))) return '';
   return `<section class="program-card-socket-section program-card-socket-section--${esc(title.toLowerCase())}"><h4 class="program-card-socket-section__heading">${esc(title)}</h4><div class="program-card-socket-list">${items}</div></section>`;
 }
 

--- a/tools/sitegen/test/render.test.js
+++ b/tools/sitegen/test/render.test.js
@@ -35,6 +35,22 @@ test('card renderer exposes accessible generated panel tabs and default state', 
   assert.match(html, /By A &amp; B/);
 });
 
+test('generated socket descriptions preserve unused physical jack positions', () => {
+  const generated = card({
+    panel_views: {
+      source: 'generated', default: 'middle', items: [{
+        id: 'middle', name: 'Middle', switch_modes: {}, leds: [],
+        panel: { inputs: {
+          audio_l: { label: 'Audio input' },
+          cv_1: { label: 'Speed CV' },
+        } },
+      }],
+    },
+  });
+  const html = renderCardArticle({ card: generated, panelImg: 'panel.svg', yamlUrl: 'source.yaml' });
+  assert.match(html, /Audio 1[\s\S]*program-card-socket--empty" aria-hidden="true"><span>Unused<\/span>[\s\S]*CV 1/);
+});
+
 test('custom panel rendering sanitizes authored content and escapes image metadata', () => {
   const custom = card({ panel_views: {
     source: 'custom', default: 'face-a', items: [{


### PR DESCRIPTION
Fix #293 

This pull request improves the rendering and accessibility of unused physical jack positions in program cards. It ensures that unused positions are visually indicated and remain present in the markup, while also hiding them on mobile for a cleaner layout. The changes also add a test to verify this behavior.

**Rendering and Accessibility Improvements:**

* Unused physical jack positions are now rendered as visually distinct elements with the label "Unused" and proper ARIA attributes, ensuring they are preserved in the DOM for accessibility and layout consistency. (`render/cardPage.js`, `program-cards.css`) [[1]](diffhunk://#diff-742331731aebd1ba6882a2330b5156eea3884c2eaceb4c5cd7ad5f6b13fea845L253-R261) [[2]](diffhunk://#diff-e804c36d6aad4880b418525e22bc126a4f4330dcc0168b60992b07db6adaaa2fR1146-R1154)
* On mobile layouts, these unused socket elements are hidden to reduce visual clutter. (`program-cards.css`)

**Testing:**

* Added a test to confirm that unused physical jack positions are preserved and rendered as expected in the generated HTML. (`render.test.js`)