### PR TITLE
Render tap as a distinct switch action

### DIFF
--- a/tools/sitegen/assets/program-cards.css
+++ b/tools/sitegen/assets/program-cards.css
@@ -589,6 +589,12 @@ a.program-card-tag:visited {
   border-color: var(--program-card-ink);
 }
 
+.program-card-position-button:disabled {
+  border-color: #aaa;
+  cursor: default;
+  opacity: 1;
+}
+
 .program-card-position-button:focus-visible {
   outline: 3px solid var(--program-card-rule);
   outline-offset: 2px;
@@ -653,11 +659,6 @@ a.program-card-tag:visited {
   border: 2px solid var(--program-card-ink);
   padding: 16px;
   font-weight: var(--weight-bold);
-}
-
-.program-card-switch-action {
-  border-left: 3px solid var(--program-card-rule);
-  padding-left: 10px;
 }
 
 .program-card-use__title {

--- a/tools/sitegen/src/render/cardPage.js
+++ b/tools/sitegen/src/render/cardPage.js
@@ -103,7 +103,9 @@ function renderPanelSwitchPositions(switchModes = {}, positionControl = null) {
   const selected = positionControl?.activeId || 'middle';
   const selectable = new Set((positionControl?.items || []).map(item => item.id));
   const positions = ['up', 'middle', 'down'].map(position => {
-    const role = switchModeName(switchModes[position]);
+    const hasDownPosition = selectable.has('down') || Boolean(switchModes.down);
+    const mode = position === 'down' && !hasDownPosition ? switchModes.tap : switchModes[position];
+    const role = switchModeName(mode);
     const selectAttrs = selectable.has(position)
       ? ` data-panel-position-button="${position}" aria-pressed="${position === selected}" title="Select ${position} switch position"`
       : ` aria-pressed="false" title="${role ? 'Edit' : 'Add'} ${position} switch position"`;
@@ -138,7 +140,10 @@ function renderSwitchSection(snapshot, positionControl = null) {
       </div>`;
     }).join('');
     const tap = switchModes.tap
-      ? `<div class="program-card-switch-position program-card-switch-action"><strong>Tap</strong><p>${esc(truncate(switchModes.tap, 240))}</p></div>`
+      ? `<div class="program-card-switch-position program-card-switch-position--tap">
+        <button type="button" class="program-card-position-button" disabled>Tap</button>
+        <p>${esc(truncate(switchModes.tap, 240))}</p>
+      </div>`
       : '';
     if (!rows && !tap) return '';
     return `<div class="program-card-control program-card-control--switch">
@@ -147,16 +152,18 @@ function renderSwitchSection(snapshot, positionControl = null) {
     </div>`;
   }
 
-  const entries = Object.entries(switchModes).filter(entry => entry[1]);
-  if (!entries.length) return '';
+  const entries = Object.entries(switchModes).filter(([key, value]) => key !== 'tap' && value);
+  const tap = switchModes.tap
+    ? `<p class="program-card-switch-action"><strong>Tap</strong> ${esc(truncate(switchModes.tap, 240))}</p>`
+    : '';
+  if (!entries.length && !tap) return '';
   const markup = entries.map(([key, value]) => {
-    const label = key === 'tap' ? 'Tap (Down)' : key.charAt(0).toUpperCase() + key.slice(1);
-    const className = key === 'tap' ? ' class="program-card-switch-action"' : '';
-    return `<p${className}><strong>${esc(label)}</strong> ${esc(truncate(value, 240))}</p>`;
+    const label = key.charAt(0).toUpperCase() + key.slice(1);
+    return `<p><strong>${esc(label)}</strong> ${esc(truncate(value, 240))}</p>`;
   }).join('');
   return `<div class="program-card-control program-card-control--switch">
     <strong class="program-card-component-key">Switch</strong>
-    <div class="program-card-switch-positions">${markup}</div>
+    <div class="program-card-switch-positions">${markup}</div>${tap}
   </div>`;
 }
 

--- a/tools/sitegen/test/render.test.js
+++ b/tools/sitegen/test/render.test.js
@@ -21,7 +21,7 @@ test('card renderer exposes accessible generated panel tabs and default state', 
     panel_views: {
       source: 'generated', default: 'middle', items: [
         { id: 'up', name: 'Up', panel: { controls: { main: { label: 'Upper\nmode' } } }, switch_modes: {}, leds: [] },
-        { id: 'middle', name: 'Middle', panel: { controls: { main: { label: 'Normal' } } }, switch_modes: {}, leds: [] },
+        { id: 'middle', name: 'Middle', panel: { controls: { main: { label: 'Normal' } } }, switch_modes: { tap: 'Set tempo' }, leds: [] },
       ],
     },
   });
@@ -31,6 +31,8 @@ test('card renderer exposes accessible generated panel tabs and default state', 
   assert.match(html, /data-panel-position-view="up" hidden aria-hidden="true"/);
   assert.match(html, /data-panel-position-view="middle"/);
   assert.match(html, /Upper<br>mode/);
+  assert.match(html, /program-card-switch-position--tap">\s*<button type="button" class="program-card-position-button" disabled>Tap<\/button>\s*<p>Set tempo<\/p>/);
+  assert.doesNotMatch(html, /data-panel-position-button="tap"/);
   assert.match(html, /Test &amp; &quot;Card&quot;/);
   assert.match(html, /By A &amp; B/);
 });
@@ -49,6 +51,19 @@ test('generated socket descriptions preserve unused physical jack positions', ()
   });
   const html = renderCardArticle({ card: generated, panelImg: 'panel.svg', yamlUrl: 'source.yaml' });
   assert.match(html, /Audio 1[\s\S]*program-card-socket--empty" aria-hidden="true"><span>Unused<\/span>[\s\S]*CV 1/);
+});
+
+test('tap labels the panel down position only when no down mode is provided', () => {
+  const tapOnly = renderPanelArtwork({ panel: {}, switch_modes: { tap: 'Tap Tempo: Set the clock' } }, 'panel.svg');
+  assert.match(tapOnly, /program-card-panel-switch-position--down[^>]*aria-label="down switch position: Tap Tempo"[^>]*>[\s\S]*<strong>Tap Tempo<\/strong>/);
+  assert.doesNotMatch(tapOnly, /data-panel-position-button="tap"/);
+
+  const withDown = renderPanelArtwork({
+    panel: {},
+    switch_modes: { down: 'Reset: Hold to clear', tap: 'Tap Tempo: Set the clock' },
+  }, 'panel.svg');
+  assert.match(withDown, /program-card-panel-switch-position--down[^>]*aria-label="down switch position: Reset"[^>]*>[\s\S]*<strong>Reset<\/strong>/);
+  assert.doesNotMatch(withDown, /aria-label="down switch position: Tap Tempo"/);
 });
 
 test('custom panel rendering sanitizes authored content and escapes image metadata', () => {


### PR DESCRIPTION
FIx #281 

This pull request improves the rendering and accessibility of "tap" switch positions in program cards, ensuring that the "tap" action is clearly distinguished from other switch positions and is only shown as a substitute for "down" when no "down" mode is present. It also refines the visual styling and updates related tests to verify the new behavior.

**Rendering and logic improvements for "tap" switch position:**

* Updated `renderPanelSwitchPositions` to only label the "down" position as "tap" if there is no explicit "down" mode, ensuring correct fallback logic.
* Modified `renderSwitchSection` to separate "tap" from other switch positions, improving clarity and markup structure. "Tap" is now rendered with a disabled button for consistency and accessibility. [[1]](diffhunk://#diff-742331731aebd1ba6882a2330b5156eea3884c2eaceb4c5cd7ad5f6b13fea845L141-R146) [[2]](diffhunk://#diff-742331731aebd1ba6882a2330b5156eea3884c2eaceb4c5cd7ad5f6b13fea845L150-R166)

**Styling changes:**

* Added a CSS rule for `.program-card-position-button:disabled` to visually indicate disabled state for the "tap" button.
* Removed the `.program-card-switch-action` CSS class, as its role is now handled differently in the markup.

**Test updates:**

* Enhanced tests to check that the "tap" button is rendered correctly, is disabled, and that "tap" is only used for the "down" position when appropriate. [[1]](diffhunk://#diff-0c0bfbe195088f186db854d35145fb8817a69e2ced82e739c38d2a4981700f5dL24-R24) [[2]](diffhunk://#diff-0c0bfbe195088f186db854d35145fb8817a69e2ced82e739c38d2a4981700f5dR34-R52)
* Added a new test to verify that "tap" labels the panel "down" position only when no "down" mode is provided, ensuring correct accessibility labeling and markup.