### PR TITLE
Rank authored dates ahead of inferred dates

### DIFF
--- a/tools/sitegen/assets/js/catalogue-filters.js
+++ b/tools/sitegen/assets/js/catalogue-filters.js
@@ -114,13 +114,17 @@
     var items = Array.from(sortContainer.children);
     function idx(el){ return Number(el.getAttribute('data-idx'))||0; }
     function dv(el){ var d=el.getAttribute('data-date')||''; return d==='n/a'?'':d; }
+    // Authored dates are authoritative. Git-inferred dates still order cards
+    // that lack authored metadata, but cannot make a newly imported placeholder
+    // appear newer than cards with real release dates.
+    function dr(el){ return !dv(el)?2:(el.getAttribute('data-date-inferred')==='true'?1:0); }
     function nv(el){ return Number(el.getAttribute('data-num'))||0; }
     function nm(el){ return el.getAttribute('data-name')||''; }
     items.sort(function(a,b){
       var da, db;
       switch(mode){
-        case 'created-desc': da=dv(a); db=dv(b); if(!da&&!db) return idx(a)-idx(b); if(!da) return 1; if(!db) return -1; return db.localeCompare(da);
-        case 'created-asc': da=dv(a); db=dv(b); if(!da&&!db) return idx(a)-idx(b); if(!da) return 1; if(!db) return -1; return da.localeCompare(db);
+        case 'created-desc': if(dr(a)!==dr(b)) return dr(a)-dr(b); da=dv(a); db=dv(b); if(!da&&!db) return idx(a)-idx(b); return db.localeCompare(da);
+        case 'created-asc': if(dr(a)!==dr(b)) return dr(a)-dr(b); da=dv(a); db=dv(b); if(!da&&!db) return idx(a)-idx(b); return da.localeCompare(db);
         case 'name-asc': return nm(a).localeCompare(nm(b));
         case 'name-desc': return nm(b).localeCompare(nm(a));
         case 'number-asc': return nv(a)-nv(b);

--- a/tools/sitegen/src/render/discovery.js
+++ b/tools/sitegen/src/render/discovery.js
@@ -83,6 +83,7 @@ export function renderTile(card, opts = {}) {
   const summary = card.short_description || '';
   const metadata = card.metadata || {};
   const sortDate = metadata.created || '';
+  const inferredDate = metadata.created_inferred ? 'true' : 'false';
   const firstVideo = Array.isArray(card.videos) && card.videos[0];
   const featuredCopy = showArtwork ? FEATURED_COPY[card.id] : null;
 
@@ -108,7 +109,7 @@ export function renderTile(card, opts = {}) {
 
   return `<article class="program-card-tile${media ? ' program-card-tile--video' : ''}${artwork ? ' program-card-tile--artwork' : ''}"` +
     ` data-creator="${escapeAttr(metadata.creator || '')}" data-language="${escapeAttr(metadata.language || '')}"` +
-    ` data-type="${escapeAttr(metadata.status || '')}" data-date="${escapeAttr(sortDate)}"` +
+    ` data-type="${escapeAttr(metadata.status || '')}" data-date="${escapeAttr(sortDate)}" data-date-inferred="${inferredDate}"` +
     ` data-name="${escapeAttr(String(card.title || card.id || '').toLowerCase())}" data-num="${escapeAttr(String(parseInt(number, 10) || 0))}"` +
     ` data-tags="${escapeAttr(tagFilter)}" data-search="${escapeAttr(searchText)}">
     <a class="program-card-tile__link" href="${card.id === '88_Blank' && showArtwork ? `${root}/random/` : `${root}/programs/${card.slug}/`}">
@@ -174,10 +175,11 @@ function renderArchiveRow(card, root) {
   const searchText = [number, card.title, summary, card.metadata?.creator, ...(Array.isArray(card.tags) ? card.tags : []), ...flair.map(f => f.label)]
     .filter(Boolean).join(' ').toLowerCase();
   const date = card.metadata?.created || '';
+  const inferredDate = card.metadata?.created_inferred ? 'true' : 'false';
   const flairFilter = flair.map(f => f.id);
   const authorTagFilter = (Array.isArray(card.tags) ? card.tags : []).map(tag => curation.slugify(tag)).filter(Boolean);
   const tagFilter = [...new Set([...flairFilter, ...authorTagFilter])].join(' ');
-  return `<article class="program-card-archive-row" data-creator="${escapeAttr(card.metadata?.creator || '')}" data-date="${escapeAttr(date)}" data-name="${escapeAttr(String(card.title || '').toLowerCase())}" data-num="${escapeAttr(String(parseInt(number, 10) || 0))}" data-tags="${escapeAttr(tagFilter)}" data-search="${escapeAttr(searchText)}">
+  return `<article class="program-card-archive-row" data-creator="${escapeAttr(card.metadata?.creator || '')}" data-date="${escapeAttr(date)}" data-date-inferred="${inferredDate}" data-name="${escapeAttr(String(card.title || '').toLowerCase())}" data-num="${escapeAttr(String(parseInt(number, 10) || 0))}" data-tags="${escapeAttr(tagFilter)}" data-search="${escapeAttr(searchText)}">
     <a class="program-card-archive-row__link" href="${root}/programs/${card.slug}/">
       <span class="program-card-archive-row__number">${esc(number)}</span>
       <span class="program-card-archive-row__main"><span class="program-card-archive-row__heading"><span class="program-card-archive-row__title">${esc(card.title)}</span>${card.metadata?.creator ? `<span class="program-card-archive-row__byline">by ${esc(card.metadata.creator)}</span>` : ''}</span>${summary ? `<span class="program-card-archive-row__summary">${esc(truncate(summary, 120))}</span>` : ''}</span>

--- a/tools/sitegen/test/render.test.js
+++ b/tools/sitegen/test/render.test.js
@@ -160,7 +160,7 @@ test('discovery renderers escape searchable attributes and ignore absent shelf c
   });
   const tile = renderTile(testCard, { showCreator: true });
   assert.match(tile, /data-creator="A&amp;B &lt;maker&gt;"/);
-  assert.match(tile, /data-date="2025-01-01"/);
+  assert.match(tile, /data-date="2025-01-01" data-date-inferred="false"/);
   assert.match(tile, /data-name="a &quot;quoted&quot; &lt;card&gt;"/);
   assert.match(tile, /…/);
   assert.match(renderArchive([testCard]), /\.\.\/programs\/safe-slug\//);
@@ -173,8 +173,8 @@ test('catalogue sorting uses inferred creation dates', () => {
   const inferred = card({
     metadata: { created: '2026-07-29', created_inferred: true },
   });
-  assert.match(renderTile(inferred), /data-date="2026-07-29"/);
-  assert.match(renderArchive([inferred]), /data-date="2026-07-29"/);
+  assert.match(renderTile(inferred), /data-date="2026-07-29" data-date-inferred="true"/);
+  assert.match(renderArchive([inferred]), /data-date="2026-07-29" data-date-inferred="true"/);
 });
 
 test('featured blank card overlays its label artwork on the randomized card icon', () => {


### PR DESCRIPTION
This pull request improves how program cards are sorted and rendered by distinguishing between authored and inferred creation dates. It ensures that cards with real (authored) release dates are prioritized over those with inferred dates, and updates the rendering logic and tests to include and check for this distinction.

Sorting logic improvements:

* Updated `catalogue-filters.js` to prioritize cards with authored dates over those with inferred dates when sorting by creation date, preventing placeholders with inferred dates from appearing newer than cards with real release dates.

Rendering changes:

* Modified `renderTile` and `renderArchiveRow` in `discovery.js` to add a new `data-date-inferred` attribute to each card, indicating whether the creation date is inferred. [[1]](diffhunk://#diff-c116525a31614fcebe4cda98217c2837f723bf5dc89782eef528d308a70c3e76R86) [[2]](diffhunk://#diff-c116525a31614fcebe4cda98217c2837f723bf5dc89782eef528d308a70c3e76L111-R112) [[3]](diffhunk://#diff-c116525a31614fcebe4cda98217c2837f723bf5dc89782eef528d308a70c3e76R178-R182)

Test updates:

* Updated tests in `render.test.js` to check for the presence and correct value of the new `data-date-inferred` attribute in rendered output. [[1]](diffhunk://#diff-0c0bfbe195088f186db854d35145fb8817a69e2ced82e739c38d2a4981700f5dL163-R163) [[2]](diffhunk://#diff-0c0bfbe195088f186db854d35145fb8817a69e2ced82e739c38d2a4981700f5dL176-R177)