### PR TITLE
feat(sitegen): allow content: auto in custom panel manifests

### DIFF
--- a/documentation/info.yaml.md
+++ b/documentation/info.yaml.md
@@ -223,10 +223,11 @@ panels:
 
 - `id` is a stable, unique lowercase kebab-case identifier used by `when.panel` and direct panel links.
 - `name` is arbitrary display text and may be changed without changing the ID.
-- `image` and `content` are safe paths relative to `panels/`; absolute paths, traversal, and symbolic links are rejected.
+- `image` is a safe path relative to `panels/`; absolute paths, traversal, and symbolic links are rejected.
+- `content` is a safe relative Markdown path, or `auto` (or omitted).
 - `default` must name a valid panel ID. Manifest order is display order.
 - Every image must be a self-contained SVG with `viewBox="0 0 560 1785"`. Generated/downloaded SVGs use the documentation-default intrinsic viewport of `width="280"` and `height="892.5"`. Scripts, `foreignObject`, event handlers, and external resources are rejected.
-- Every presentation requires companion Markdown. It is rendered beside the image instead of the generated controls/I/O/LED reference, and provides the accessible textual explanation of text embedded in the image.
+- When companion Markdown is supplied for `content`, it is rendered beside the image. When `content: auto` is specified (or omitted), sitegen automatically renders the classic 2-column socket cards, control lists, and LEDs from `info.yaml` for that tab.
 - Relative images and links in the Markdown resolve inside `panels/`.
 
 Physical component IDs do not change. Use `main`, `x`, `y`, ComputerCard jack IDs, and LED IDs as usual; use a manifest panel ID only as the condition:

--- a/tools/sitegen/src/discover/customPanels.js
+++ b/tools/sitegen/src/discover/customPanels.js
@@ -126,17 +126,19 @@ export async function readCustomPanelManifest(absReleaseDir) {
     const id = typeof raw.id === 'string' ? raw.id.trim() : '';
     const name = typeof raw.name === 'string' ? raw.name.trim() : '';
     const image = safeRelativePath(raw.image);
-    const content = safeRelativePath(raw.content);
+    const contentRaw = typeof raw.content === 'string' ? raw.content.trim() : '';
+    const isAuto = !contentRaw || contentRaw.toLowerCase() === 'auto';
+    const content = isAuto ? 'auto' : safeRelativePath(raw.content);
     let valid = true;
     if (!PANEL_ID.test(id)) { diagnostics.push(diagnostic('error', `${at}.id`, 'id must be unique lowercase kebab-case.')); valid = false; }
     if (ids.has(id.toLowerCase())) { diagnostics.push(diagnostic('error', `${at}.id`, `Duplicate panel id "${id}".`)); valid = false; }
     if (!name) { diagnostics.push(diagnostic('error', `${at}.name`, 'name must be non-empty text.')); valid = false; }
     if (!image) { diagnostics.push(diagnostic('error', `${at}.image`, 'image must be a safe relative SVG path.')); valid = false; }
-    if (!content) { diagnostics.push(diagnostic('error', `${at}.content`, 'content must be a safe relative Markdown path.')); valid = false; }
+    if (!isAuto && !content) { diagnostics.push(diagnostic('error', `${at}.content`, 'content must be a safe relative Markdown path or "auto".')); valid = false; }
     if (image && path.posix.extname(image).toLowerCase() !== '.svg') { diagnostics.push(diagnostic('error', `${at}.image`, 'image must be an SVG file.')); valid = false; }
-    if (content && path.posix.extname(content).toLowerCase() !== '.md') { diagnostics.push(diagnostic('error', `${at}.content`, 'content must be a Markdown file.')); valid = false; }
+    if (!isAuto && content && path.posix.extname(content).toLowerCase() !== '.md') { diagnostics.push(diagnostic('error', `${at}.content`, 'content must be a Markdown file or "auto".')); valid = false; }
     if (id) ids.add(id.toLowerCase());
-    if (valid) items.push({ id, name, image, content, index, at });
+    if (valid) items.push({ id, name, image, content, index, at, isAuto });
   }
 
   const requestedDefault = typeof manifest.default === 'string' ? manifest.default.trim() : '';
@@ -160,14 +162,14 @@ export async function discoverCustomPanels(absReleaseDir, outProgramDir, { copyA
   if (!source.manifest || !source.items.length) return { present: true, panels: empty, diagnostics };
   const items = [];
   for (const declared of source.items) {
-    const { id, name, at } = declared;
+    const { id, name, at, isAuto } = declared;
     const imagePath = declared.image;
     const contentPath = declared.content;
     let valid = true;
     const imageFile = await regularFileInside(panelsDir, imagePath);
-    const contentFile = await regularFileInside(panelsDir, contentPath);
+    const contentFile = isAuto ? null : await regularFileInside(panelsDir, contentPath);
     if (!imageFile) { diagnostics.push(diagnostic('error', `${at}.image`, `Missing or unsafe file "${imagePath}".`)); valid = false; }
-    if (!contentFile) { diagnostics.push(diagnostic('error', `${at}.content`, `Missing or unsafe file "${contentPath}".`)); valid = false; }
+    if (!isAuto && !contentFile) { diagnostics.push(diagnostic('error', `${at}.content`, `Missing or unsafe file "${contentPath}".`)); valid = false; }
     if (!valid) continue;
 
     const metadata = await svgMetadata(imageFile);
@@ -175,16 +177,27 @@ export async function discoverCustomPanels(absReleaseDir, outProgramDir, { copyA
       diagnostics.push(diagnostic('error', `${at}.image`, `"${imagePath}" ${metadata.error}`));
       continue;
     }
-    const markdown = await fs.readFile(contentFile, 'utf8');
-    if (!markdown.trim()) diagnostics.push(diagnostic('warning', `${at}.content`, `"${contentPath}" is empty.`));
-    items.push({
-      id,
-      name,
-      kind: 'custom',
-      image: { url: assetUrl(imagePath), format: 'svg', width: metadata.width, height: metadata.height },
-      content_html: rewritePanelHtmlLinks(renderMarkdownBlock(markdown), contentPath),
-      source: { image: `panels/${imagePath}`, content: `panels/${contentPath}` },
-    });
+    if (isAuto) {
+      items.push({
+        id,
+        name,
+        kind: 'generated',
+        image: { url: assetUrl(imagePath), format: 'svg', width: metadata.width, height: metadata.height },
+        content_html: null,
+        source: { image: `panels/${imagePath}` },
+      });
+    } else {
+      const markdown = await fs.readFile(contentFile, 'utf8');
+      if (!markdown.trim()) diagnostics.push(diagnostic('warning', `${at}.content`, `"${contentPath}" is empty.`));
+      items.push({
+        id,
+        name,
+        kind: 'custom',
+        image: { url: assetUrl(imagePath), format: 'svg', width: metadata.width, height: metadata.height },
+        content_html: rewritePanelHtmlLinks(renderMarkdownBlock(markdown), contentPath),
+        source: { image: `panels/${imagePath}`, content: `panels/${contentPath}` },
+      });
+    }
   }
 
   const requestedDefault = source.default;

--- a/tools/sitegen/src/discover/customPanels.js
+++ b/tools/sitegen/src/discover/customPanels.js
@@ -125,21 +125,24 @@ export async function readCustomPanelManifest(absReleaseDir) {
     }
     const id = typeof raw.id === 'string' ? raw.id.trim() : '';
     const name = typeof raw.name === 'string' ? raw.name.trim() : '';
-    const image = safeRelativePath(raw.image);
+    const imageOmitted = !Object.hasOwn(raw, 'image');
+    const imageRaw = typeof raw.image === 'string' ? raw.image.trim() : '';
+    const isImageAuto = imageOmitted || imageRaw.toLowerCase() === 'auto';
+    const image = isImageAuto ? 'auto' : safeRelativePath(raw.image);
     const contentOmitted = !Object.hasOwn(raw, 'content');
     const contentRaw = typeof raw.content === 'string' ? raw.content.trim() : '';
-    const isAuto = contentOmitted || contentRaw.toLowerCase() === 'auto';
-    const content = isAuto ? 'auto' : safeRelativePath(raw.content);
+    const isContentAuto = contentOmitted || contentRaw.toLowerCase() === 'auto';
+    const content = isContentAuto ? 'auto' : safeRelativePath(raw.content);
     let valid = true;
     if (!PANEL_ID.test(id)) { diagnostics.push(diagnostic('error', `${at}.id`, 'id must be unique lowercase kebab-case.')); valid = false; }
     if (ids.has(id.toLowerCase())) { diagnostics.push(diagnostic('error', `${at}.id`, `Duplicate panel id "${id}".`)); valid = false; }
     if (!name) { diagnostics.push(diagnostic('error', `${at}.name`, 'name must be non-empty text.')); valid = false; }
-    if (!image) { diagnostics.push(diagnostic('error', `${at}.image`, 'image must be a safe relative SVG path.')); valid = false; }
-    if (!isAuto && !content) { diagnostics.push(diagnostic('error', `${at}.content`, 'content must be a safe relative Markdown path or "auto".')); valid = false; }
-    if (image && path.posix.extname(image).toLowerCase() !== '.svg') { diagnostics.push(diagnostic('error', `${at}.image`, 'image must be an SVG file.')); valid = false; }
-    if (!isAuto && content && path.posix.extname(content).toLowerCase() !== '.md') { diagnostics.push(diagnostic('error', `${at}.content`, 'content must be a Markdown file or "auto".')); valid = false; }
+    if (!isImageAuto && !image) { diagnostics.push(diagnostic('error', `${at}.image`, 'image must be a safe relative SVG path or "auto".')); valid = false; }
+    if (!isContentAuto && !content) { diagnostics.push(diagnostic('error', `${at}.content`, 'content must be a safe relative Markdown path or "auto".')); valid = false; }
+    if (!isImageAuto && image && path.posix.extname(image).toLowerCase() !== '.svg') { diagnostics.push(diagnostic('error', `${at}.image`, 'image must be an SVG file or "auto".')); valid = false; }
+    if (!isContentAuto && content && path.posix.extname(content).toLowerCase() !== '.md') { diagnostics.push(diagnostic('error', `${at}.content`, 'content must be a Markdown file or "auto".')); valid = false; }
     if (id) ids.add(id.toLowerCase());
-    if (valid) items.push({ id, name, image, content, index, at, isAuto });
+    if (valid) items.push({ id, name, image, content, index, at, isImageAuto, isContentAuto });
   }
 
   const requestedDefault = typeof manifest.default === 'string' ? manifest.default.trim() : '';
@@ -163,42 +166,46 @@ export async function discoverCustomPanels(absReleaseDir, outProgramDir, { copyA
   if (!source.manifest || !source.items.length) return { present: true, panels: empty, diagnostics };
   const items = [];
   for (const declared of source.items) {
-    const { id, name, at, isAuto } = declared;
+    const { id, name, at, isImageAuto, isContentAuto } = declared;
     const imagePath = declared.image;
     const contentPath = declared.content;
     let valid = true;
-    const imageFile = await regularFileInside(panelsDir, imagePath);
-    const contentFile = isAuto ? null : await regularFileInside(panelsDir, contentPath);
-    if (!imageFile) { diagnostics.push(diagnostic('error', `${at}.image`, `Missing or unsafe file "${imagePath}".`)); valid = false; }
-    if (!isAuto && !contentFile) { diagnostics.push(diagnostic('error', `${at}.content`, `Missing or unsafe file "${contentPath}".`)); valid = false; }
+    const imageFile = isImageAuto ? null : await regularFileInside(panelsDir, imagePath);
+    const contentFile = isContentAuto ? null : await regularFileInside(panelsDir, contentPath);
+    if (!isImageAuto && !imageFile) { diagnostics.push(diagnostic('error', `${at}.image`, `Missing or unsafe file "${imagePath}".`)); valid = false; }
+    if (!isContentAuto && !contentFile) { diagnostics.push(diagnostic('error', `${at}.content`, `Missing or unsafe file "${contentPath}".`)); valid = false; }
     if (!valid) continue;
 
-    const metadata = await svgMetadata(imageFile);
-    if (metadata.error) {
-      diagnostics.push(diagnostic('error', `${at}.image`, `"${imagePath}" ${metadata.error}`));
-      continue;
+    let image;
+    if (!isImageAuto) {
+      const metadata = await svgMetadata(imageFile);
+      if (metadata.error) {
+        diagnostics.push(diagnostic('error', `${at}.image`, `"${imagePath}" ${metadata.error}`));
+        continue;
+      }
+      image = { url: assetUrl(imagePath), format: 'svg', width: metadata.width, height: metadata.height };
     }
-    if (isAuto) {
-      items.push({
-        id,
-        name,
-        kind: 'generated',
-        image: { url: assetUrl(imagePath), format: 'svg', width: metadata.width, height: metadata.height },
-        content_html: null,
-        source: { image: `panels/${imagePath}` },
-      });
-    } else {
+
+    let contentHtml = null;
+    if (!isContentAuto) {
       const markdown = await fs.readFile(contentFile, 'utf8');
       if (!markdown.trim()) diagnostics.push(diagnostic('warning', `${at}.content`, `"${contentPath}" is empty.`));
-      items.push({
-        id,
-        name,
-        kind: 'custom',
-        image: { url: assetUrl(imagePath), format: 'svg', width: metadata.width, height: metadata.height },
-        content_html: rewritePanelHtmlLinks(renderMarkdownBlock(markdown), contentPath),
-        source: { image: `panels/${imagePath}`, content: `panels/${contentPath}` },
-      });
+      contentHtml = rewritePanelHtmlLinks(renderMarkdownBlock(markdown), contentPath);
     }
+
+    const item = {
+      id,
+      name,
+      kind: isContentAuto ? 'generated' : 'custom',
+      image_kind: isImageAuto ? 'generated' : 'custom',
+      content_kind: isContentAuto ? 'generated' : 'custom',
+      content_html: contentHtml,
+      source: {},
+    };
+    if (image) item.image = image;
+    if (!isImageAuto) item.source.image = `panels/${imagePath}`;
+    if (!isContentAuto) item.source.content = `panels/${contentPath}`;
+    items.push(item);
   }
 
   const requestedDefault = source.default;

--- a/tools/sitegen/src/discover/customPanels.js
+++ b/tools/sitegen/src/discover/customPanels.js
@@ -126,8 +126,9 @@ export async function readCustomPanelManifest(absReleaseDir) {
     const id = typeof raw.id === 'string' ? raw.id.trim() : '';
     const name = typeof raw.name === 'string' ? raw.name.trim() : '';
     const image = safeRelativePath(raw.image);
+    const contentOmitted = !Object.hasOwn(raw, 'content');
     const contentRaw = typeof raw.content === 'string' ? raw.content.trim() : '';
-    const isAuto = !contentRaw || contentRaw.toLowerCase() === 'auto';
+    const isAuto = contentOmitted || contentRaw.toLowerCase() === 'auto';
     const content = isAuto ? 'auto' : safeRelativePath(raw.content);
     let valid = true;
     if (!PANEL_ID.test(id)) { diagnostics.push(diagnostic('error', `${at}.id`, 'id must be unique lowercase kebab-case.')); valid = false; }

--- a/tools/sitegen/src/model/card.js
+++ b/tools/sitegen/src/model/card.js
@@ -377,7 +377,7 @@ function normalizeControls(info, warnings, position, panelId = '') {
   return controls;
 }
 
-function normalizeSwitchModes(info, warnings) {
+function normalizeSwitchModes(info, warnings, { inferFromRows = true } = {}) {
   const modes = { up: '', middle: '', down: '', tap: '' };
 
   const controlsSwitch = field(field(info, 'controls'), 'switch');
@@ -394,6 +394,8 @@ function normalizeSwitchModes(info, warnings) {
     }
     return modes;
   }
+
+  if (!inferFromRows) return modes;
 
   const rows = listValue(field(field(info, 'controls'), 'knobs'), warnings, 'controls.knobs');
   for (const mode of Z_MODES) {
@@ -581,7 +583,7 @@ export function buildCanonicalCardModel({
   const hasUf2Metadata = uf2Metadata != null
     && (!Array.isArray(uf2Metadata) || uf2Metadata.length > 0);
 
-  const switchModes = normalizeSwitchModes(info, warnings);
+  const switchModes = normalizeSwitchModes(info, warnings, { inferFromRows: !customPanels });
   const panelViews = Z_MODES
     .filter(position => hasPositionMetadata(info, position))
     .map(position => resolvePanelView(info, warnings, position, switchModes));

--- a/tools/sitegen/src/render/cardPage.js
+++ b/tools/sitegen/src/render/cardPage.js
@@ -167,7 +167,7 @@ function renderSwitchSection(snapshot, positionControl = null) {
   </div>`;
 }
 
-function renderPanelReference(snapshot, panelImg, positionControl = null) {
+function renderGeneratedPanelCopy(snapshot, positionControl = null) {
   const panel = snapshot.panel || {};
   const controls = panel.controls || {};
   const controlsMarkup = panelPositions.controls.filter(pos => pos.key !== 'z').map(pos => {
@@ -183,14 +183,11 @@ function renderPanelReference(snapshot, panelImg, positionControl = null) {
   const outputsMarkup = renderSocketList('Outputs', panel.outputs, panelPositions.outputs);
   const ledsMarkup = renderLedList(snapshot.leds);
 
-  return `<div class="program-card-use">
-    <div class="program-card-use__panel">${renderPanel(panel, panelImg, positionControl, snapshot.switch_modes)}</div>
-    <div class="program-card-use__reference">
+  return `<div class="program-card-use__reference">
       ${controlsMarkup || switchMarkup ? `<details class="program-card-section program-card-collapsible program-card-controls-section" open><summary><h3>Controls</h3></summary><div class="program-card-control-list">${controlsMarkup}${switchMarkup}</div></details>` : ''}
       ${inputsMarkup || outputsMarkup ? `<details class="program-card-section program-card-collapsible program-card-io-section" open><summary class="program-card-io-summary"><h3 class="program-card-io-mobile-heading">${inputsMarkup && outputsMarkup ? 'Inputs &amp; Outputs' : inputsMarkup ? 'Inputs' : 'Outputs'}</h3><span class="program-card-io-headings">${inputsMarkup ? '<h3>Inputs</h3>' : '<span></span>'}${outputsMarkup ? '<h3>Outputs</h3>' : ''}</span></summary><div class="program-card-io-columns">${inputsMarkup}${outputsMarkup}</div></details>` : ''}
       ${ledsMarkup}
-    </div>
-  </div>`;
+    </div>`;
 }
 
 function renderCustomPanelImage(item) {
@@ -201,9 +198,22 @@ function renderCustomPanelImage(item) {
   return `<figure class="program-card-panel program-card-panel--custom"><img src="${esc(image.url)}" width="${width}" height="${height}" alt="${esc(item.name || 'Custom panel')} panel"></figure>`;
 }
 
-function renderCustomPanelReference(item) {
+function renderPanelVisual(item, panelImg, positionControl = null) {
+  return item?.image?.url
+    ? renderCustomPanelImage(item)
+    : renderPanel(item?.panel || {}, panelImg, positionControl, item?.switch_modes || {});
+}
+
+function renderPanelReference(item, panelImg, positionControl = null) {
+  return `<div class="program-card-use">
+    <div class="program-card-use__panel">${renderPanelVisual(item, panelImg, positionControl)}</div>
+    ${renderGeneratedPanelCopy(item, positionControl)}
+  </div>`;
+}
+
+function renderCustomPanelReference(item, panelImg) {
   return `<div class="program-card-use program-card-use--custom">
-    <div class="program-card-use__panel">${renderCustomPanelImage(item)}</div>
+    <div class="program-card-use__panel">${renderPanelVisual(item, panelImg)}</div>
     <div class="program-card-use__reference program-card-custom-panel-copy markdown-body">${sanitizeAuthoredHtml(item.content_html || '')}</div>
   </div>`;
 }
@@ -234,11 +244,11 @@ function renderPanelViews(card, panelImg) {
   const selected = items.find(item => item.id === card.panel_views.default) || items[0];
   const groupId = `panel-views-${card.slug || card.id || 'card'}`;
   const views = items.map(item => {
-    const isCustom = item.kind === 'custom' || Boolean(item.content_html);
-    const itemSvg = item.image?.url || panelImg;
-    const viewInner = isCustom
-      ? renderCustomPanelReference(item)
-      : renderPanelReference(item.panel ? item : { panel: card.panel || {}, switch_modes: card.switch_modes, leds: card.leds }, itemSvg, custom ? null : { items, groupId, activeId: item.id });
+    const hasCustomContent = item.content_kind === 'custom' || (!item.content_kind && (item.kind === 'custom' || Boolean(item.content_html)));
+    const snapshot = item.panel ? item : { ...item, panel: card.panel || {}, switch_modes: card.switch_modes, leds: card.leds };
+    const viewInner = hasCustomContent
+      ? renderCustomPanelReference(snapshot, panelImg)
+      : renderPanelReference(snapshot, panelImg, custom ? null : { items, groupId, activeId: item.id });
     return `<div id="${esc(groupId)}-${esc(item.id)}" class="program-card-position-view" data-panel-position-view="${esc(item.id)}"${item.id === selected.id ? '' : ' hidden aria-hidden="true"'}>
     ${viewInner}
   </div>`;
@@ -256,7 +266,7 @@ function renderPanelRail(card, panelImg) {
 
   const selected = items.find(item => item.id === card.panel_views.default) || items[0];
   const groupId = `panel-views-${card.slug || card.id || 'card'}`;
-  const panels = items.map(item => `<div class="program-card-rail-view" data-panel-position-panel="${esc(item.id)}"${item.id === selected.id ? '' : ' hidden aria-hidden="true"'}>${custom ? renderCustomPanelImage(item) : renderPanel(item.panel || {}, panelImg, { items, groupId, activeId: item.id }, item.switch_modes)}</div>`).join('');
+  const panels = items.map(item => `<div class="program-card-rail-view" data-panel-position-panel="${esc(item.id)}"${item.id === selected.id ? '' : ' hidden aria-hidden="true"'}>${renderPanelVisual(item, panelImg, custom ? null : { items, groupId, activeId: item.id })}</div>`).join('');
   return `<aside class="program-card-panel-rail" aria-label="Panel visualization">${panels}</aside>`;
 }
 

--- a/tools/sitegen/src/render/cardPage.js
+++ b/tools/sitegen/src/render/cardPage.js
@@ -233,9 +233,16 @@ function renderPanelViews(card, panelImg) {
 
   const selected = items.find(item => item.id === card.panel_views.default) || items[0];
   const groupId = `panel-views-${card.slug || card.id || 'card'}`;
-  const views = items.map(item => `<div id="${esc(groupId)}-${esc(item.id)}" class="program-card-position-view" data-panel-position-view="${esc(item.id)}"${item.id === selected.id ? '' : ' hidden aria-hidden="true"'}>
-    ${custom ? renderCustomPanelReference(item) : renderPanelReference(item, panelImg, { items, groupId, activeId: item.id })}
-  </div>`).join('');
+  const views = items.map(item => {
+    const isCustom = item.kind === 'custom' || Boolean(item.content_html);
+    const itemSvg = item.image?.url || panelImg;
+    const viewInner = isCustom
+      ? renderCustomPanelReference(item)
+      : renderPanelReference(item.panel ? item : { panel: card.panel || {}, switch_modes: card.switch_modes, leds: card.leds }, itemSvg, custom ? null : { items, groupId, activeId: item.id });
+    return `<div id="${esc(groupId)}-${esc(item.id)}" class="program-card-position-view" data-panel-position-view="${esc(item.id)}"${item.id === selected.id ? '' : ' hidden aria-hidden="true"'}>
+    ${viewInner}
+  </div>`;
+  }).join('');
   return `<div class="program-card-panel-views${custom ? ' program-card-panel-views--custom' : ''}">${renderPanelSelector(items, selected, groupId, custom ? '' : 'Switch')}${views}</div>`;
 }
 

--- a/tools/sitegen/test/card-panels.test.js
+++ b/tools/sitegen/test/card-panels.test.js
@@ -102,6 +102,15 @@ test('custom panels preserve order, select their default, and suppress generated
   assert.equal(card.panel_views.items[0].panel.controls.main.label, 'Shared');
   assert.equal(card.panel_views.items[1].panel.controls.main.label, 'Alternate main');
   assert.ok(!card.panel_views.items.some(item => item.id === 'up'));
+  assert.deepEqual(card.switch_modes, { up: '', middle: '', down: '', tap: '' });
+  assert.deepEqual(card.panel_views.items[0].switch_modes, card.switch_modes);
+
+  const explicitSwitch = build({
+    Name: 'Panel Test',
+    controls: { switch: { up: 'Freeze', middle: 'Run', down: 'Reset' } },
+  }, { customPanels });
+  assert.equal(explicitSwitch.switch_modes.up, 'Freeze');
+  assert.equal(explicitSwitch.panel_views.items[0].switch_modes.down, 'Reset');
 
   const invalidOverride = build({ Name: 'Panel Test', controls: { switch: { up: 'Up' } } }, {
     customPanels: { source: 'custom', default: '', items: [] },

--- a/tools/sitegen/test/discovery.test.js
+++ b/tools/sitegen/test/discovery.test.js
@@ -186,7 +186,7 @@ panels:
   assert.ok(references.some(diagnostic => diagnostic.path === 'controls.knobs[0].when.panel'));
 });
 
-test('custom panel discovery accepts content: auto for generated presentation tabs', async t => {
+test('custom panel discovery accepts multiple generated and hybrid presentation tabs', async t => {
   const release = await fixture(t);
   const output = path.join(release, '..', 'output');
   await write(path.join(release, 'panels', 'manifest.yaml'), `
@@ -197,6 +197,9 @@ panels:
     name: Main panel
     image: main.svg
     content: auto
+  - id: secondary
+    name: Secondary panel
+    image: secondary.svg
   - id: alternate
     name: Alternate
     image: alternate.svg
@@ -204,6 +207,7 @@ panels:
 `);
   const svg = '<svg viewBox="0 0 560 1785"><rect width="560" height="1785"/></svg>';
   await write(path.join(release, 'panels', 'main.svg'), svg);
+  await write(path.join(release, 'panels', 'secondary.svg'), svg);
   await write(path.join(release, 'panels', 'alternate.svg'), svg);
   await write(path.join(release, 'panels', 'alternate.md'), '# Alternate');
 
@@ -211,6 +215,23 @@ panels:
   assert.equal(result.present, true);
   assert.equal(result.panels.items[0].kind, 'generated');
   assert.equal(result.panels.items[0].content_html, null);
-  assert.equal(result.panels.items[1].kind, 'custom');
+  assert.equal(result.panels.items[1].kind, 'generated');
+  assert.equal(result.panels.items[1].content_html, null);
+  assert.equal(result.panels.items[2].kind, 'custom');
   assert.deepEqual(result.diagnostics, []);
+});
+
+test('custom panel discovery rejects blank and non-string content values', async t => {
+  const release = await fixture(t);
+  await write(path.join(release, 'panels', 'manifest.yaml'), `
+version: 1
+default: blank
+panels:
+  - { id: blank, name: Blank, image: blank.svg, content: "" }
+  - { id: numeric, name: Numeric, image: numeric.svg, content: 42 }
+`);
+
+  const result = await discoverCustomPanels(release, path.join(release, '..', 'output'));
+  assert.deepEqual(result.panels.items, []);
+  assert.equal(result.diagnostics.filter(diagnostic => diagnostic.path.endsWith('.content')).length, 2);
 });

--- a/tools/sitegen/test/discovery.test.js
+++ b/tools/sitegen/test/discovery.test.js
@@ -199,29 +199,39 @@ panels:
     content: auto
   - id: secondary
     name: Secondary panel
-    image: secondary.svg
   - id: alternate
     name: Alternate
     image: alternate.svg
     content: alternate.md
+  - id: textual
+    name: Textual
+    image: auto
+    content: textual.md
 `);
   const svg = '<svg viewBox="0 0 560 1785"><rect width="560" height="1785"/></svg>';
   await write(path.join(release, 'panels', 'main.svg'), svg);
-  await write(path.join(release, 'panels', 'secondary.svg'), svg);
   await write(path.join(release, 'panels', 'alternate.svg'), svg);
   await write(path.join(release, 'panels', 'alternate.md'), '# Alternate');
+  await write(path.join(release, 'panels', 'textual.md'), '# Textual');
 
   const result = await discoverCustomPanels(release, output);
   assert.equal(result.present, true);
   assert.equal(result.panels.items[0].kind, 'generated');
+  assert.equal(result.panels.items[0].image_kind, 'custom');
   assert.equal(result.panels.items[0].content_html, null);
   assert.equal(result.panels.items[1].kind, 'generated');
+  assert.equal(result.panels.items[1].image_kind, 'generated');
+  assert.equal(result.panels.items[1].image, undefined);
   assert.equal(result.panels.items[1].content_html, null);
   assert.equal(result.panels.items[2].kind, 'custom');
+  assert.equal(result.panels.items[2].image_kind, 'custom');
+  assert.equal(result.panels.items[3].content_kind, 'custom');
+  assert.equal(result.panels.items[3].image_kind, 'generated');
+  assert.equal(result.panels.items[3].image, undefined);
   assert.deepEqual(result.diagnostics, []);
 });
 
-test('custom panel discovery rejects blank and non-string content values', async t => {
+test('custom panel discovery rejects blank and non-string auto-capable values', async t => {
   const release = await fixture(t);
   await write(path.join(release, 'panels', 'manifest.yaml'), `
 version: 1
@@ -229,9 +239,12 @@ default: blank
 panels:
   - { id: blank, name: Blank, image: blank.svg, content: "" }
   - { id: numeric, name: Numeric, image: numeric.svg, content: 42 }
+  - { id: blank-image, name: Blank image, image: "", content: auto }
+  - { id: numeric-image, name: Numeric image, image: 42, content: auto }
 `);
 
   const result = await discoverCustomPanels(release, path.join(release, '..', 'output'));
   assert.deepEqual(result.panels.items, []);
   assert.equal(result.diagnostics.filter(diagnostic => diagnostic.path.endsWith('.content')).length, 2);
+  assert.equal(result.diagnostics.filter(diagnostic => diagnostic.path.endsWith('.image')).length, 2);
 });

--- a/tools/sitegen/test/discovery.test.js
+++ b/tools/sitegen/test/discovery.test.js
@@ -185,3 +185,32 @@ panels:
   }, result.panels);
   assert.ok(references.some(diagnostic => diagnostic.path === 'controls.knobs[0].when.panel'));
 });
+
+test('custom panel discovery accepts content: auto for generated presentation tabs', async t => {
+  const release = await fixture(t);
+  const output = path.join(release, '..', 'output');
+  await write(path.join(release, 'panels', 'manifest.yaml'), `
+version: 1
+default: main
+panels:
+  - id: main
+    name: Main panel
+    image: main.svg
+    content: auto
+  - id: alternate
+    name: Alternate
+    image: alternate.svg
+    content: alternate.md
+`);
+  const svg = '<svg viewBox="0 0 560 1785"><rect width="560" height="1785"/></svg>';
+  await write(path.join(release, 'panels', 'main.svg'), svg);
+  await write(path.join(release, 'panels', 'alternate.svg'), svg);
+  await write(path.join(release, 'panels', 'alternate.md'), '# Alternate');
+
+  const result = await discoverCustomPanels(release, output);
+  assert.equal(result.present, true);
+  assert.equal(result.panels.items[0].kind, 'generated');
+  assert.equal(result.panels.items[0].content_html, null);
+  assert.equal(result.panels.items[1].kind, 'custom');
+  assert.deepEqual(result.diagnostics, []);
+});

--- a/tools/sitegen/test/render.test.js
+++ b/tools/sitegen/test/render.test.js
@@ -83,6 +83,31 @@ test('custom panel rendering sanitizes authored content and escapes image metada
   assert.doesNotMatch(html, /program-card-panel-switch-position/);
 });
 
+test('hybrid panel rendering mixes generated references with authored content', () => {
+  const hybrid = card({ panel_views: {
+    source: 'custom', default: 'generated', items: [
+      {
+        id: 'generated', name: 'Generated', kind: 'generated',
+        image: { url: 'panels/generated.svg', width: 560, height: 1785 },
+        panel: { controls: { main: { label: 'Generated role' } } },
+        switch_modes: {}, leds: [], content_html: null,
+      },
+      {
+        id: 'authored', name: 'Authored', kind: 'custom',
+        image: { url: 'panels/authored.svg', width: 560, height: 1785 },
+        panel: {}, switch_modes: {}, leds: [], content_html: '<p>Authored explanation</p>',
+      },
+    ],
+  } });
+  const html = renderCardArticle({ card: hybrid, panelImg: 'panel.svg', yamlUrl: 'source.yaml' });
+  assert.match(html, /data-panel-position-view="generated"/);
+  assert.match(html, /src="panels\/generated\.svg"/);
+  assert.match(html, /Generated role/);
+  assert.match(html, /data-panel-position-view="authored" hidden aria-hidden="true"/);
+  assert.match(html, /src="panels\/authored\.svg"/);
+  assert.match(html, /Authored explanation/);
+});
+
 test('basic rendering omits generated features but keeps actions, metadata, and extra docs', () => {
   const html = renderCardArticle({
     card: card({ videos: [{ id: 'abc', url: 'https://youtu.be/abc' }], audio_samples: [{ kind: 'file', url: 'demo.mp3' }] }),

--- a/tools/sitegen/test/render.test.js
+++ b/tools/sitegen/test/render.test.js
@@ -83,19 +83,25 @@ test('custom panel rendering sanitizes authored content and escapes image metada
   assert.doesNotMatch(html, /program-card-panel-switch-position/);
 });
 
-test('hybrid panel rendering mixes generated references with authored content', () => {
+test('hybrid panel rendering selects generated or authored visuals and content independently', () => {
   const hybrid = card({ panel_views: {
     source: 'custom', default: 'generated', items: [
       {
-        id: 'generated', name: 'Generated', kind: 'generated',
+        id: 'generated', name: 'Generated', kind: 'generated', image_kind: 'custom', content_kind: 'generated',
         image: { url: 'panels/generated.svg', width: 560, height: 1785 },
         panel: { controls: { main: { label: 'Generated role' } } },
         switch_modes: {}, leds: [], content_html: null,
       },
       {
-        id: 'authored', name: 'Authored', kind: 'custom',
+        id: 'authored', name: 'Authored', kind: 'custom', image_kind: 'custom', content_kind: 'custom',
         image: { url: 'panels/authored.svg', width: 560, height: 1785 },
         panel: {}, switch_modes: {}, leds: [], content_html: '<p>Authored explanation</p>',
+      },
+      {
+        id: 'auto-visual', name: 'Auto visual', kind: 'custom', image_kind: 'generated', content_kind: 'custom',
+        panel: { controls: { x: { label: 'Automatic visual role' } } },
+        switch_modes: { up: 'Freeze', middle: 'Run', down: 'Reset' }, leds: [],
+        content_html: '<p>Automatic visual explanation</p>',
       },
     ],
   } });
@@ -106,6 +112,10 @@ test('hybrid panel rendering mixes generated references with authored content', 
   assert.match(html, /data-panel-position-view="authored" hidden aria-hidden="true"/);
   assert.match(html, /src="panels\/authored\.svg"/);
   assert.match(html, /Authored explanation/);
+  assert.match(html, /data-panel-position-view="auto-visual" hidden aria-hidden="true"/);
+  assert.match(html, /src="panel\.svg"/);
+  assert.match(html, /Automatic visual role/);
+  assert.match(html, /Automatic visual explanation/);
 });
 
 test('basic rendering omits generated features but keeps actions, metadata, and extra docs', () => {

--- a/tools/sitegen/test/site-integrity.test.js
+++ b/tools/sitegen/test/site-integrity.test.js
@@ -78,8 +78,14 @@ test('generated panel views and firmware fingerprints satisfy site invariants', 
       assert.equal(source, 'custom');
       assert.ok(itemIds.every(id => /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(id)));
       for (const item of items) {
-        assert.equal(item.image?.format, 'svg');
-        assert.ok(item.image?.url && item.image.width > 0 && item.image.height > 0);
+        assert.ok(['custom', 'generated'].includes(item.image_kind));
+        assert.ok(['custom', 'generated'].includes(item.content_kind));
+        if (item.image_kind === 'custom') {
+          assert.equal(item.image?.format, 'svg');
+          assert.ok(item.image?.url && item.image.width > 0 && item.image.height > 0);
+        } else {
+          assert.equal(item.image, undefined);
+        }
       }
     }
   }


### PR DESCRIPTION
Allows multi-page cards using `panels/manifest.yaml` to mix custom Markdown pages with auto-generated card UI.

Setting `content: auto` (or omitting `content`) on a panel tab now renders the standard 2-column socket cards, controls, and LEDs from `info.yaml` for that tab instead of requiring a `.md` file.

- **`customPanels.js`**: Accepts `content: auto` in manifest validation.
- **`cardPage.js`**: Dispatches custom vs generated renderer per tab instead of per card.
- **`discovery.test.js`**: Unit test for `content: auto`.
- **`documentation/info.yaml.md`**: Updated manifest documentation.

Tested against full test suite (`npm test`, 109/109 pass).