### PR TITLE
support youtube timestamps in main embed and readme embeds

### DIFF
--- a/documentation/info.yaml.md
+++ b/documentation/info.yaml.md
@@ -121,7 +121,7 @@ uf2:
 
 | Field | Required | Type | Description |
 |-------|----------|------|-------------|
-| `demo-link` | no | string (URL) | Optional demo video URL: YouTube (`watch`, `youtu.be`, `/shorts/`, `/embed/`) or Instagram (`/reel/`, `/reels/`, `/p/`, `/tv/`). Rendered as a demo-video thumbnail on the detail page that plays inline when clicked. Matching YouTube and Instagram links in README.md also get inline embeds (Instagram embeds use a portrait frame). |
+| `demo-link` | no | string (URL) | Optional demo video URL: YouTube (`watch`, `youtu.be`, `/shorts/`, `/embed/`) or Instagram (`/reel/`, `/reels/`, `/p/`, `/tv/`). Rendered as a demo-video thumbnail on the detail page that plays inline when clicked. YouTube time offsets (`t=` / `start=`, including `1331s` / `1h2m3s`) are preserved so playback starts at that point. Matching YouTube and Instagram links in README.md also get inline embeds (Instagram embeds use a portrait frame). |
 | `audio-sample` | no | string or list | Demo audio. Accepts a single value or a list. Each value may be: a **repo-relative file** (e.g. `samples/demo.wav`, resolved to a raw URL and rendered with an `<audio>` player); a **SoundCloud** track/set URL (embedded as a player, derived from the URL — no API key); a **Bandcamp** *EmbeddedPlayer* URL (the iframe `src` from Bandcamp's Share → Embed dialog); or any other URL (shown as a link). You may also paste a whole embed `<iframe>` snippet (we extract the player `src` + height), but you must single-quote it in YAML. List items may also be `{ url, title }` objects (`title` shows above the player). |
 ```yaml
 # single file

--- a/tools/sitegen/assets/js/program-cards.js
+++ b/tools/sitegen/assets/js/program-cards.js
@@ -57,13 +57,14 @@ function loadInstagramEmbedScript() {
   document.body.appendChild(s);
 }
 
-function demoEmbedIframe(provider, id, kind, autoplay) {
+function demoEmbedIframe(provider, id, kind, autoplay, start) {
   if (provider === 'instagram') {
     var igKind = kind || 'reel';
     var permalink = 'https://www.instagram.com/' + encodeURIComponent(igKind) + '/' + encodeURIComponent(id) + '/';
     return '<blockquote class="instagram-media" data-instgrm-permalink="' + permalink + '" data-instgrm-version="14"><a href="' + permalink + '" target="_blank" rel="noopener noreferrer">View this ' + (igKind === 'reel' ? 'reel' : 'post') + ' on Instagram</a></blockquote>';
   }
   var qs = autoplay ? '?rel=0&autoplay=1' : '?rel=0';
+  if (start) qs += '&start=' + encodeURIComponent(start);
   return '<iframe src="https://www.youtube.com/embed/' + encodeURIComponent(id) + qs + '" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen title="YouTube video"></iframe>';
 }
 
@@ -76,9 +77,10 @@ document.addEventListener('click', function(e) {
   var provider = a.getAttribute('data-video-provider') || 'youtube';
   var id = a.getAttribute('data-video-id');
   var kind = a.getAttribute('data-video-kind');
+  var start = a.getAttribute('data-video-start');
   var wrap = document.createElement('div');
   wrap.className = provider === 'instagram' ? 'instagram-embed' : 'video-embed';
-  wrap.innerHTML = demoEmbedIframe(provider, id, kind, provider === 'youtube');
+  wrap.innerHTML = demoEmbedIframe(provider, id, kind, provider === 'youtube', start);
   a.replaceWith(wrap);
   if (provider === 'instagram') loadInstagramEmbedScript();
 });
@@ -92,12 +94,14 @@ document.addEventListener('click', function(e) {
   var provider = media.getAttribute('data-video-provider') || 'youtube';
   var id = media.getAttribute('data-video-id');
   var kind = media.getAttribute('data-video-kind');
+  var start = media.getAttribute('data-video-start');
   media.classList.add('program-card-tile__media--playing');
   media.removeAttribute('data-video-provider');
   media.removeAttribute('data-video-id');
   media.removeAttribute('data-video-kind');
+  media.removeAttribute('data-video-start');
   media.removeAttribute('aria-hidden');
-  media.innerHTML = demoEmbedIframe(provider, id, kind, provider === 'youtube');
+  media.innerHTML = demoEmbedIframe(provider, id, kind, provider === 'youtube', start);
   if (provider === 'instagram') loadInstagramEmbedScript();
 });
 

--- a/tools/sitegen/src/model/card.js
+++ b/tools/sitegen/src/model/card.js
@@ -698,6 +698,7 @@ export function buildCanonicalCardModel({
       aspect: demoVideo.aspect,
     };
     if (demoVideo.kind) video.kind = demoVideo.kind;
+    if (demoVideo.start != null && demoVideo.start > 0) video.start = demoVideo.start;
     card.videos = [video];
   }
 

--- a/tools/sitegen/src/render/cardPage.js
+++ b/tools/sitegen/src/render/cardPage.js
@@ -33,7 +33,8 @@ function renderDemoSection(video) {
   if (provider === 'instagram') {
     return `<section class="program-card-demo program-card-demo--instagram">${instagramEmbedHtml(video.url)}${label}</section>`;
   }
-  return `<section class="program-card-demo"><a href="${esc(video.url)}" data-video-provider="youtube" data-video-id="${esc(video.id)}"><span class="program-card-demo__media" aria-hidden="true"><img src="https://img.youtube.com/vi/${esc(video.id)}/hqdefault.jpg" alt="" loading="lazy"></span>${label}</a></section>`;
+  const startAttr = video.start ? ` data-video-start="${esc(String(video.start))}"` : '';
+  return `<section class="program-card-demo"><a href="${esc(video.url)}" data-video-provider="youtube" data-video-id="${esc(video.id)}"${startAttr}><span class="program-card-demo__media" aria-hidden="true"><img src="https://img.youtube.com/vi/${esc(video.id)}/hqdefault.jpg" alt="" loading="lazy"></span>${label}</a></section>`;
 }
 
 function stripTags(value) {

--- a/tools/sitegen/src/render/discovery.js
+++ b/tools/sitegen/src/render/discovery.js
@@ -39,13 +39,14 @@ function renderTileMedia(video) {
   const provider = video.provider || 'youtube';
   const portrait = provider === 'instagram' || video.aspect === 'portrait';
   const kindAttr = video.kind ? ` data-video-kind="${esc(video.kind)}"` : '';
+  const startAttr = video.start ? ` data-video-start="${esc(String(video.start))}"` : '';
   const thumb = provider === 'youtube'
     ? `<img src="https://img.youtube.com/vi/${esc(video.id)}/hqdefault.jpg" alt="" loading="lazy">`
     : '<span class="program-card-tile__placeholder"></span>';
   const mediaClass = portrait
     ? 'program-card-tile__media program-card-tile__media--portrait'
     : 'program-card-tile__media';
-  return `<span class="${mediaClass}" data-video-provider="${esc(provider)}" data-video-id="${esc(video.id)}"${kindAttr} aria-hidden="true">${thumb}</span>`;
+  return `<span class="${mediaClass}" data-video-provider="${esc(provider)}" data-video-id="${esc(video.id)}"${kindAttr}${startAttr} aria-hidden="true">${thumb}</span>`;
 }
 
 function stripTags(value) {

--- a/tools/sitegen/src/utils/video.js
+++ b/tools/sitegen/src/utils/video.js
@@ -1,4 +1,4 @@
-import { parseYoutubeId, youtubeEmbedHtml } from './youtube.js';
+import { parseYoutubeId, parseYoutubeStartSeconds, youtubeEmbedHtml } from './youtube.js';
 import { parseInstagram, instagramEmbedHtml } from './instagram.js';
 
 /**
@@ -11,7 +11,10 @@ export function classifyDemoVideo(url) {
 
   const youtubeId = parseYoutubeId(u);
   if (youtubeId) {
-    return { provider: 'youtube', id: youtubeId, url: u, aspect: 'landscape' };
+    const video = { provider: 'youtube', id: youtubeId, url: u, aspect: 'landscape' };
+    const start = parseYoutubeStartSeconds(u);
+    if (start != null && start > 0) video.start = start;
+    return video;
   }
 
   const ig = parseInstagram(u);

--- a/tools/sitegen/src/utils/youtube.js
+++ b/tools/sitegen/src/utils/youtube.js
@@ -1,6 +1,24 @@
+/** Parse a YouTube time offset (`1772`, `1331s`, `1h2m3s`) into seconds. */
+function parseTimeOffset(raw) {
+  const s = String(raw || '').trim();
+  if (!s) return null;
+  if (/^\d+$/.test(s)) return Number(s);
+
+  const hms = s.match(/^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/i);
+  if (hms && (hms[1] || hms[2] || hms[3])) {
+    return (Number(hms[1] || 0) * 3600) + (Number(hms[2] || 0) * 60) + Number(hms[3] || 0);
+  }
+  return null;
+}
+
+/** Normalize hrefs pulled from sanitized HTML (`&amp;` → `&`). */
+function urlOrRaw(url) {
+  return String(url || '').replace(/&amp;/gi, '&');
+}
+
 /** Extract YouTube video ID from common URL forms. */
 export function parseYoutubeId(url) {
-  const u = String(url || '').trim();
+  const u = urlOrRaw(url).trim();
   if (!u) return null;
 
   let m = u.match(/(?:^|\b)youtu\.be\/([A-Za-z0-9_-]{6,})/i);
@@ -18,11 +36,42 @@ export function parseYoutubeId(url) {
   return null;
 }
 
+/**
+ * Extract a start offset in seconds from `t=` / `start=` query (or `#t=`) params.
+ * Returns null when absent or unparseable.
+ */
+export function parseYoutubeStartSeconds(url) {
+  const u = urlOrRaw(url).trim();
+  if (!u) return null;
+
+  let raw = null;
+  try {
+    const parsed = new URL(u);
+    raw = parsed.searchParams.get('t') || parsed.searchParams.get('start');
+    if (!raw && parsed.hash) {
+      const hm = parsed.hash.match(/[#&?]t=([^&]+)/i);
+      if (hm) raw = decodeURIComponent(hm[1]);
+    }
+  } catch {
+    const m = u.match(/[?&#](?:t|start)=([^&#]+)/i);
+    if (m) {
+      try { raw = decodeURIComponent(m[1]); }
+      catch { raw = m[1]; }
+    }
+  }
+
+  const seconds = parseTimeOffset(raw);
+  if (seconds == null || !Number.isFinite(seconds) || seconds < 0) return null;
+  return Math.floor(seconds);
+}
+
 export function youtubeEmbedHtml(urlOrId) {
   const id = parseYoutubeId(urlOrId) || (
     /^[A-Za-z0-9_-]{6,}$/.test(String(urlOrId || '').trim()) ? String(urlOrId).trim() : null
   );
   if (!id) return '';
-  const embedUrl = `https://www.youtube.com/embed/${id}?rel=0`;
+  const start = parseYoutubeStartSeconds(urlOrId);
+  const startParam = start != null && start > 0 ? `&start=${start}` : '';
+  const embedUrl = `https://www.youtube.com/embed/${id}?rel=0${startParam}`;
   return `<div class="video-embed"><iframe src="${embedUrl}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen title="YouTube video"></iframe></div>`;
 }

--- a/tools/sitegen/test/card.test.js
+++ b/tools/sitegen/test/card.test.js
@@ -102,6 +102,14 @@ test('demo-link YouTube URL produces a videos entry', () => {
   assert.equal(card.videos.length, 1);
   assert.equal(card.videos[0].id, 'dQw4w9WgXcQ');
   assert.equal(card.videos[0].provider, 'youtube');
+  assert.equal(card.videos[0].start, undefined);
+});
+
+test('demo-link YouTube URL preserves time offset as videos[].start', () => {
+  const card = build({ 'demo-link': 'https://youtu.be/ABbWmZOtmig?si=bKNxzY5MFJ0kZ6UB&t=1772' });
+  assert.equal(card.videos[0].id, 'ABbWmZOtmig');
+  assert.equal(card.videos[0].provider, 'youtube');
+  assert.equal(card.videos[0].start, 1772);
 });
 
 test('demo-link Instagram reel URL produces a videos entry', () => {

--- a/tools/sitegen/test/render.test.js
+++ b/tools/sitegen/test/render.test.js
@@ -118,6 +118,21 @@ test('demo section renders YouTube thumbnails and Instagram official embeds', ()
   assert.doesNotMatch(instagram, /program-card-demo__placeholder/);
 });
 
+test('demo video markup preserves YouTube start offset', () => {
+  const html = renderCardArticle({
+    card: card({ videos: [{ id: 'ABbWmZOtmig', url: 'https://youtu.be/ABbWmZOtmig?t=1772', start: 1772, title: 'Demo video', provider: 'youtube', aspect: 'landscape' }] }),
+    panelImg: 'panel.svg', yamlUrl: 'source.yaml',
+  });
+  assert.match(html, /data-video-id="ABbWmZOtmig"/);
+  assert.match(html, /data-video-start="1772"/);
+
+  const tile = renderTile(card({ videos: [{ id: 'ABbWmZOtmig', url: 'https://youtu.be/ABbWmZOtmig?t=1772', start: 1772, provider: 'youtube', aspect: 'landscape' }] }), {
+    showVideo: true,
+  });
+  assert.match(tile, /data-video-id="ABbWmZOtmig"/);
+  assert.match(tile, /data-video-start="1772"/);
+});
+
 test('cards without generated or custom panels omit both panel regions', () => {
   const html = renderCardArticle({ card: card(), panelImg: 'panel.svg', yamlUrl: 'source.yaml' });
   assert.doesNotMatch(html, /program-card-use-section/);

--- a/tools/sitegen/test/utils.test.js
+++ b/tools/sitegen/test/utils.test.js
@@ -7,6 +7,7 @@ import { normalizeTags, normalizeDraft, normalizeContact, resolveAudioSample } f
 import { extractIframeSrc, classifyAudioUrl, resolveAudioSamples } from '../src/utils/audio.js';
 import { parseInstagram, instagramEmbedHtml } from '../src/utils/instagram.js';
 import { classifyDemoVideo, videoEmbedHtml } from '../src/utils/video.js';
+import { parseYoutubeId, parseYoutubeStartSeconds, youtubeEmbedHtml } from '../src/utils/youtube.js';
 
 test('normalizeYamlKey strips spaces and hyphens, lowercases', () => {
   assert.equal(normalizeYamlKey('demo-link'), 'demolink');
@@ -110,6 +111,10 @@ test('classifyDemoVideo and videoEmbedHtml cover YouTube and Instagram', () => {
   assert.equal(yt.id, 'dQw4w9WgXcQ');
   assert.match(videoEmbedHtml(yt.url), /youtube\.com\/embed\/dQw4w9WgXcQ/);
 
+  const ytOffset = classifyDemoVideo('https://youtu.be/ABbWmZOtmig?t=1772');
+  assert.equal(ytOffset.start, 1772);
+  assert.match(videoEmbedHtml(ytOffset.url), /start=1772/);
+
   const ig = classifyDemoVideo('https://www.instagram.com/reel/DMKkotPsItQ/');
   assert.equal(ig.provider, 'instagram');
   assert.equal(ig.kind, 'reel');
@@ -118,4 +123,47 @@ test('classifyDemoVideo and videoEmbedHtml cover YouTube and Instagram', () => {
 
   assert.equal(classifyDemoVideo('https://example.com/video'), null);
   assert.equal(videoEmbedHtml('https://example.com/video'), '');
+});
+
+test('parseYoutubeId handles watch, youtu.be, shorts, and embed URLs', () => {
+  assert.equal(parseYoutubeId('https://www.youtube.com/watch?v=dQw4w9WgXcQ'), 'dQw4w9WgXcQ');
+  assert.equal(parseYoutubeId('https://youtu.be/ABbWmZOtmig?t=1772'), 'ABbWmZOtmig');
+  assert.equal(parseYoutubeId('https://www.youtube.com/shorts/abcdef12345'), 'abcdef12345');
+  assert.equal(parseYoutubeId('https://www.youtube.com/embed/abcdef12345'), 'abcdef12345');
+  assert.equal(parseYoutubeId('https://example.com/watch?v=nope'), null);
+});
+
+test('parseYoutubeStartSeconds preserves t= and start= offsets', () => {
+  assert.equal(parseYoutubeStartSeconds('https://youtu.be/ABbWmZOtmig?si=x&t=1772'), 1772);
+  assert.equal(parseYoutubeStartSeconds('https://www.youtube.com/watch?v=ABbWmZOtmig&t=1331s'), 1331);
+  assert.equal(parseYoutubeStartSeconds('https://www.youtube.com/watch?v=ABbWmZOtmig&t=1h2m3s'), 3723);
+  assert.equal(parseYoutubeStartSeconds('https://www.youtube.com/embed/ABbWmZOtmig?start=90'), 90);
+  assert.equal(parseYoutubeStartSeconds('https://www.youtube.com/watch?v=ABbWmZOtmig#t=45s'), 45);
+  assert.equal(parseYoutubeStartSeconds('https://www.youtube.com/watch?v=ABbWmZOtmig'), null);
+});
+
+test('parseYoutubeStartSeconds tolerates &amp; from sanitized README hrefs', () => {
+  // sanitize-html encodes & in attributes; t= after another param becomes &amp;t=
+  assert.equal(
+    parseYoutubeStartSeconds('https://youtu.be/ABbWmZOtmig?si=bKNxzY5MFJ0kZ6UB&amp;t=1772'),
+    1772,
+  );
+  assert.equal(
+    parseYoutubeStartSeconds('https://www.youtube.com/watch?v=VFnUbPqJ7lY&amp;t=65s'),
+    65,
+  );
+  assert.equal(
+    parseYoutubeStartSeconds('https://youtu.be/D0H_VsJ15go?t=4819&amp;si=7J1yqLwJx2xuIX9x'),
+    4819,
+  );
+});
+
+test('youtubeEmbedHtml includes start= when the source URL has a time offset', () => {
+  const html = youtubeEmbedHtml('https://youtu.be/ABbWmZOtmig?t=1772');
+  assert.match(html, /youtube\.com\/embed\/ABbWmZOtmig\?rel=0&start=1772/);
+  assert.match(
+    youtubeEmbedHtml('https://youtu.be/ABbWmZOtmig?si=x&amp;t=1772'),
+    /start=1772/,
+  );
+  assert.doesNotMatch(youtubeEmbedHtml('https://youtu.be/ABbWmZOtmig'), /start=/);
 });


### PR DESCRIPTION
- Preserve YouTube time offsets (`t=` / `start=`, including `1331s` / `1h2m3s`) when converting links to embeds
- Applies to both `demo-link` click-to-play and README inline embeds
- Decode `&amp;` in sanitized README hrefs so offsets after other query params are not dropped

Fixes #324
