### PR TITLE
Fix issue with video-lead vs video-strip

### DIFF
--- a/tools/sitegen/src/render/discovery.js
+++ b/tools/sitegen/src/render/discovery.js
@@ -155,7 +155,6 @@ function shelfCards(shelf, cardsById) {
 export function renderShelf(shelf, cardsById, opts = {}) {
   const { featured = false, root = '.' } = opts;
   const layout = shelf.layout || '';
-  const showVideo = layout.includes('video');
   const list = shelfCards(shelf, cardsById);
   if (!list.length) return '';
 
@@ -165,7 +164,12 @@ export function renderShelf(shelf, cardsById, opts = {}) {
 
   return `<section class="${classes}">
     <header class="program-card-shelf__header"><h2>${esc(shelf.title || 'Shelf')}</h2>${shelf.intro ? `<p>${esc(shelf.intro)}</p>` : ''}</header>
-    <div class="${gridClasses}">${list.map(card => renderTile(card, { showVideo, showArtwork: featured, hideFlairs: shelf.hide_flairs, root })).join('')}</div>
+    <div class="${gridClasses}">${list.map((card, index) => renderTile(card, {
+      showVideo: layout === 'video-strip' || (layout === 'video-lead' && index === 0),
+      showArtwork: featured,
+      hideFlairs: shelf.hide_flairs,
+      root,
+    })).join('')}</div>
   </section>`;
 }
 

--- a/tools/sitegen/test/render.test.js
+++ b/tools/sitegen/test/render.test.js
@@ -240,6 +240,34 @@ test('discovery renderers escape searchable attributes and ignore absent shelf c
   assert.equal((shelf.match(/program-card-tile__link/g) || []).length, 1);
 });
 
+test('video shelf layouts show media on the intended cards', () => {
+  const cards = [
+    card({ id: '01_lead', slug: '01-lead', videos: [{ id: 'lead-video' }] }),
+    card({ id: '02_support', slug: '02-support', videos: [{ id: 'support-video' }] }),
+    card({ id: '03_support', slug: '03-support', videos: [{ id: 'another-video' }] }),
+  ];
+  const cardsById = new Map(cards.map(item => [item.id, item]));
+  const shelf = { title: 'Videos', cards: cards.map(item => item.id) };
+
+  const lead = renderShelf({ ...shelf, layout: 'video-lead' }, cardsById);
+  assert.equal((lead.match(/program-card-tile__media/g) || []).length, 1);
+  assert.match(lead, /data-video-id="lead-video"/);
+  assert.doesNotMatch(lead, /data-video-id="support-video"|data-video-id="another-video"/);
+  assert.equal((lead.match(/program-card-tile--video/g) || []).length, 1);
+
+  const strip = renderShelf({ ...shelf, layout: 'video-strip' }, cardsById);
+  assert.equal((strip.match(/program-card-tile__media/g) || []).length, 3);
+  assert.match(strip, /data-video-id="lead-video"/);
+  assert.match(strip, /data-video-id="support-video"/);
+  assert.match(strip, /data-video-id="another-video"/);
+
+  const leadWithoutVideo = renderShelf(
+    { ...shelf, layout: 'video-lead' },
+    new Map(cards.map((item, index) => [item.id, index === 0 ? { ...item, videos: [] } : item])),
+  );
+  assert.doesNotMatch(leadWithoutVideo, /program-card-tile__media|program-card-tile--video/);
+});
+
 test('catalogue sorting uses inferred creation dates', () => {
   const inferred = card({
     metadata: { created: '2026-07-29', created_inferred: true },


### PR DESCRIPTION
Fixes #333 

This pull request updates how video shelf layouts are rendered in the discovery section and adds tests to ensure the correct cards display media elements. The main change is to make the display of videos in shelf layouts more precise and predictable, especially for the `video-lead` and `video-strip` layouts.

**Rendering logic improvements:**

* In `renderShelf` (`tools/sitegen/src/render/discovery.js`), the logic for showing videos on cards is now based on the layout: only the first card shows a video in `video-lead`, while all cards show videos in `video-strip`. This replaces the previous, less precise approach. [[1]](diffhunk://#diff-c116525a31614fcebe4cda98217c2837f723bf5dc89782eef528d308a70c3e76L158) [[2]](diffhunk://#diff-c116525a31614fcebe4cda98217c2837f723bf5dc89782eef528d308a70c3e76L168-R172)

**Test coverage:**

* Added a test in `render.test.js` to verify that the correct cards display video media elements for both `video-lead` and `video-strip` layouts, including edge cases where the lead card has no video.

After the fix the root page looks like this:

<img width="1094" height="1097" alt="image" src="https://github.com/user-attachments/assets/b35c043f-cdfe-4d4b-9b88-ef5e354d78dd" />

 