### PR TITLE
Markov (60_markov): info.yaml conversion to new format, draft false

### DIFF
--- a/releases/60_markov/README.md
+++ b/releases/60_markov/README.md
@@ -122,22 +122,22 @@ In **Dual Melody mode**, the right column (1, 3, 5) shows voice B profile instea
 
 Twelve scales arranged CCW (dark/minor) to CW (bright/ambiguous):
 
-LED display shows the scale index in 6-bit binary across all six LEDs (X = lit, O = off). Left column = LEDs 0/2/4 (bits 0/1/2), right column = LEDs 1/3/5 (bits 3/4/5), read top to bottom.
+LED display shows the scale index in 6-bit binary across all six LEDs (X = lit, O = off). Bit *n* lights LED *n*, and the LEDs are numbered left to right then top to bottom — so bits 0/1 are the top row, 2/3 the middle row, and 4/5 the bottom row.
 
 | Index | LEDs | Scale | Notes | Character |
 |-------|------|-------|-------|-----------|
 | 0 | `OO`<br>`OO`<br>`OO` | **Phrygian** | 7 | Dark, unresolved minor. The flat 2nd gives an ancient or Spanish flavour. |
 | 1 | `XO`<br>`OO`<br>`OO` | **Hirajōshi** | 5 | Tense, cinematic minor. A Japanese koto scale with wide leaps. |
-| 2 | `OO`<br>`XO`<br>`OO` | **Harmonic Minor** | 7 | Dramatic; the augmented 2nd between ♭6 and 7 is the defining interval. |
-| 3 | `XO`<br>`XO`<br>`OO` | **Natural Minor** | 7 | The standard minor centre. Neutral and versatile. *(Default)* |
-| 4 | `OO`<br>`OO`<br>`XO` | **Minor Pentatonic** | 5 | Open, classic minor. No semitone steps; very forgiving. |
-| 5 | `XO`<br>`OO`<br>`XO` | **m7 Arpeggio** | 4 | Root, ♭3, 5, ♭7 only. Pure minor 7th chord tones. |
-| 6 | `OO`<br>`XO`<br>`XO` | **Dorian** | 7 | Minor with a raised 6th. Sophisticated — melancholic but lifted. |
-| 7 | `XO`<br>`XO`<br>`XO` | **Major Pentatonic** | 5 | Open, consonant major. Pastoral and unambiguous. |
-| 8 | `OX`<br>`OO`<br>`OO` | **Ionian (Major)** | 7 | The standard major scale. Bright and resolved. |
-| 9 | `XX`<br>`OO`<br>`OO` | **Maj7 Arpeggio** | 4 | Root, 3, 5, 7. Pure major 7th chord tones. Lush and stable. |
-| 10 | `OX`<br>`XO`<br>`OO` | **Whole Tone** | 6 | Dreamy, floating, rootless. Every interval is a tone; no leading-note pull. |
-| 11 | `XX`<br>`XO`<br>`OO` | **Chromatic** | 12 | All 12 semitones. The raw Markov output — total ambiguity. |
+| 2 | `OX`<br>`OO`<br>`OO` | **Harmonic Minor** | 7 | Dramatic; the augmented 2nd between ♭6 and 7 is the defining interval. |
+| 3 | `XX`<br>`OO`<br>`OO` | **Natural Minor** | 7 | The standard minor centre. Neutral and versatile. *(Default)* |
+| 4 | `OO`<br>`XO`<br>`OO` | **Minor Pentatonic** | 5 | Open, classic minor. No semitone steps; very forgiving. |
+| 5 | `XO`<br>`XO`<br>`OO` | **m7 Arpeggio** | 4 | Root, ♭3, 5, ♭7 only. Pure minor 7th chord tones. |
+| 6 | `OX`<br>`XO`<br>`OO` | **Dorian** | 7 | Minor with a raised 6th. Sophisticated — melancholic but lifted. |
+| 7 | `XX`<br>`XO`<br>`OO` | **Major Pentatonic** | 5 | Open, consonant major. Pastoral and unambiguous. |
+| 8 | `OO`<br>`OX`<br>`OO` | **Ionian (Major)** | 7 | The standard major scale. Bright and resolved. |
+| 9 | `XO`<br>`OX`<br>`OO` | **Maj7 Arpeggio** | 4 | Root, 3, 5, 7. Pure major 7th chord tones. Lush and stable. |
+| 10 | `OX`<br>`OX`<br>`OO` | **Whole Tone** | 6 | Dreamy, floating, rootless. Every interval is a tone; no leading-note pull. |
+| 11 | `XX`<br>`OX`<br>`OO` | **Chromatic** | 12 | All 12 semitones. The raw Markov output — total ambiguity. |
 
 ---
 

--- a/releases/60_markov/info.yaml
+++ b/releases/60_markov/info.yaml
@@ -1,104 +1,135 @@
-draft: true
+draft: false
 Name: Markov
-short-description: Dual generative Markov chain module — evolving melody (MarkoV) left side, rhythmic percussion patterns (MarkovPerc) right side, with internal synth voice
-Language: C++ (Pico SDK)
+short-description: Dual generative Markov chain module — evolving melody left, rhythmic percussion right, with internal synth voice
+summary: >-
+  Two independent Markov chain engines run in parallel from a shared clock — a melodic generator
+  on the left side and a rhythmic percussion generator on the right — combined by an internal
+  square-wave synth voice into a self-contained generative instrument. Knob X selects one of five
+  melodic transition profiles, Knob Y one of four percussion profiles, and the Main knob changes
+  role with the switch: pre-scale transpose (up), loop lock and mutation (middle), or scale select
+  while held (down). Hold the switch down at power-on for Dual Melody mode, where both engines
+  become melodic voices.
+Language: C++ (RP2040 Pico SDK)
 Creator: Andy Jenkinson (uglifruit)
 Version: 1.0.0
 Status: Released
+License: MIT
 date-created: 2026-05-30
-date-updated: 2026-05-30
+date-updated: 2026-08-04
+repository: https://github.com/TomWhitwell/Workshop_Computer/tree/main/releases/60_markov
 
-summary: |
-  Dual Markov-chain generator with melody on voice A and rhythm/percussion on voice B.
-  Knob X selects melodic transition profile, Knob Y selects percussion profile, and
-  Main is switch-dependent: transpose (Z up), loop lock/mutate length (Z middle), or
-  scale select while held (Z down). Pulse In 1 clocks both chains; CV Out 1 carries
-  melody pitch, Pulse Out 1 emits pitch-change gate, Pulse Out 2 emits percussion
-  triggers/ratchets/flams, and CV Out 2 carries percussion accent.
+tags:
+  - generative
+  - markov
+  - sequencer
+  - melody
+  - percussion
+  - quantiser
+
+uf2:
+  - path: UF2/markov.uf2
+    name: Markov v1.0.0
 
 panel:
   inputs:
     - id: PulseIn1
       name: Master Clock
-      description: Rising edge advances both Markov chains; after timeout the module falls back to internal CV-controlled tempo
+      type: pulse
+      description: Rising edge advances both Markov chains; falls back to the CV In 2 internal clock after 3 seconds with no pulse
     - id: CVIn1
-      name: Melody Post-Scale Transpose
-      description: Bipolar semitone transpose applied after scale quantization (disabled while scale-select switch down is held)
+      name: Post-Scale Transpose
+      type: cv
+      description: Bipolar ±12 semitone shift applied after scale quantisation; 0V is no shift, and the input is frozen while the switch is held down
     - id: CVIn2
-      name: Internal Tempo CV
-      description: Internal tempo control when external clock is absent
+      name: Internal Tempo
+      type: cv
+      description: Sets internal tempo when Pulse In 1 is absent — 0V is 120 BPM, ranging roughly 20–220 BPM. In Dual Melody mode this becomes post-scale transpose for voice B
   outputs:
-    - id: PulseOut1
-      name: Melody Change Gate
-      description: Short pulse when quantized melody pitch changes
     - id: CVOut1
       name: Melody Pitch CV
-      description: Quantized melody pitch output (V/Oct calibrated by firmware mapping)
+      type: cv
+      description: Quantised V/Oct pitch for the melody chain, hardware calibrated
+    - id: PulseOut1
+      name: Melody Change Gate
+      type: pulse
+      description: 10ms gate fired only when the quantised melody pitch changes from the previous step
     - id: PulseOut2
       name: Percussion Trigger
-      description: Markov percussion trigger output including ratchets/flams
+      type: pulse
+      description: Triggers for percussion hits, firing multiple times per clock for ratchets and flams. In Dual Melody mode this becomes the voice B gate
     - id: CVOut2
       name: Percussion Accent CV
-      description: Accent level CV derived from percussion state
+      type: cv
+      description: Accent level across five steps — 0V for a rest up to +5V for a full accent. In Dual Melody mode this becomes voice B pitch CV
     - id: AudioOut1
       name: Internal Synth Voice A
-      description: Square-wave synth voice tied to melody chain and percussion gating
+      type: audio
+      description: Square-wave oscillator pitched by the melody chain, shaped by a long decaying envelope and gated by percussion hits
     - id: AudioOut2
-      name: Internal Output B / Dual Melody Voice B
-      description: Unused in primary mode; outputs second synth voice in dual melody mode
+      name: Internal Synth Voice B
+      type: audio
+      description: Unused in primary mode; carries the independent voice B synth in Dual Melody mode
 
 controls:
+  switch:
+    up:
+      name: Transpose
+      description: Main knob sets melody base note from −12 to +12 semitones, applied before scale quantisation so it changes which scale degrees are played
+    middle:
+      name: Loop & Lock
+      description: Main knob is symmetric around centre — centre is free running, clockwise locks a clean 16/8/4/3/2 beat replay of what just played, counter-clockwise locks the same replay with a 1-in-8 per-step chance of Markov mutation
+    down:
+      name: Scale Select
+      description: Momentary. While held, the Main knob selects one of twelve quantisation scales and all six LEDs show the index in binary. Held at power-on instead selects Dual Melody mode
   knobs:
-    - when: { z: middle }
-      main:
-        name: Loop Lock Length / Mutation
-        description: Center is free run; clockwise locks fixed replay lengths, counter-clockwise locks replay with probabilistic per-step mutation
-      x:
-        name: Melody Profile
-        description: Selects one of five melodic transition profiles
-      y:
-        name: Percussion Profile
-        description: Selects one of four percussion transition profiles (or voice B profile in dual melody mode)
     - when: { z: up }
       main:
         name: Base Transpose
-        description: Pre-scale transpose applied to generated melody
+        description: Pre-scale transpose from −12 to +12 semitones, centre is 0
       x:
         name: Melody Profile
-        description: Selects one of five melodic transition profiles
+        description: Selects one of five melodic transition profiles — Pentatonic Stability, Chromatic Tension, Jazz Tendencies, Glacial, Drone
       y:
         name: Percussion Profile
-        description: Selects one of four percussion transition profiles (or voice B profile in dual melody mode)
+        description: Selects one of four percussion transition profiles — Steady, Syncopated, Jazz/Free, Sparse (voice B melodic profile in Dual Melody mode)
+    - when: { z: middle }
+      main:
+        name: Loop Length / Mutation
+        description: Centre is free run; clockwise locks a fixed 16/8/4/3/2 beat replay, counter-clockwise locks the same lengths with probabilistic per-step mutation
+      x:
+        name: Melody Profile
+        description: Selects one of five melodic transition profiles — Pentatonic Stability, Chromatic Tension, Jazz Tendencies, Glacial, Drone
+      y:
+        name: Percussion Profile
+        description: Selects one of four percussion transition profiles — Steady, Syncopated, Jazz/Free, Sparse (voice B melodic profile in Dual Melody mode)
     - when: { z: down, gesture: hold }
       main:
         name: Scale Select
-        description: Selects quantization scale index while switch is held down
+        description: Selects the quantisation scale index from 0 to 11 while the switch is held; the new scale takes effect on the next clock pulse
       x:
         name: Melody Profile
-        description: Profile selection remains available outside the momentary scale-select action
+        description: Profile selection remains available outside the momentary scale-select gesture
       y:
         name: Percussion Profile
-        description: Profile selection remains available outside the momentary scale-select action
-
+        description: Profile selection remains available outside the momentary scale-select gesture
   leds:
-    - when: { z: any }
-      display: list
+    - display: list
       items:
-        - id: LED0
-          name: Left Column Bit 0 / Loop Length Indicator
-          description: Shows melody profile bit 0 during Knob X feedback; participates in scale binary display; used as loop length indicator for 16-beat lock
-        - id: LED1
+        - id: led0
+          name: Left Column Bit 0
+          description: Melody profile bit 0 during Knob X feedback; scale binary bit 0 while the switch is held down; loop length indicator for a 16-beat lock
+        - id: led1
           name: Right Column Bit 0
-          description: Shows percussion (or dual voice B) profile bit 0 during Knob Y feedback; participates in scale binary display
-        - id: LED2
-          name: Left Column Bit 1 / Loop Length Indicator
-          description: Shows melody profile bit 1 during Knob X feedback; participates in scale binary display; used as loop length indicator for 8-beat lock
-        - id: LED3
-          name: Right Column Bit 1 / Loop Length Indicator
-          description: Shows percussion (or dual voice B) profile bit 1 during Knob Y feedback; participates in scale binary display; used as loop length indicator for 2-beat lock
-        - id: LED4
-          name: Left Column Bit 2 / Loop Length Indicator
-          description: Shows melody profile bit 2 during Knob X feedback; participates in scale binary display; used as loop length indicator for 4-beat lock
-        - id: LED5
-          name: Right Column Bit 2 / Loop Length Indicator
-          description: Shows percussion (or dual voice B) profile bit 2 during Knob Y feedback; participates in scale binary display; used as loop length indicator for 3-beat lock
+          description: Percussion profile bit 0 during Knob Y feedback; scale binary bit 1 while the switch is held down
+        - id: led2
+          name: Left Column Bit 1
+          description: Melody profile bit 1 during Knob X feedback; scale binary bit 2 while the switch is held down; loop length indicator for an 8-beat lock
+        - id: led3
+          name: Right Column Bit 1
+          description: Percussion profile bit 1 during Knob Y feedback; scale binary bit 3 while the switch is held down; loop length indicator for a 2-beat lock
+        - id: led4
+          name: Left Column Bit 2
+          description: Melody profile bit 2 during Knob X feedback; scale binary bit 4 while the switch is held down; loop length indicator for a 4-beat lock
+        - id: led5
+          name: Right Column Bit 2
+          description: Percussion profile bit 2 during Knob Y feedback; scale binary bit 5 while the switch is held down; loop length indicator for a 3-beat lock

--- a/releases/60_markov/info.yaml
+++ b/releases/60_markov/info.yaml
@@ -108,10 +108,10 @@ controls:
       y:
         name: Percussion Profile
         description: Selects one of four percussion transition profiles — Steady, Syncopated, Jazz/Free, Sparse (voice B melodic profile in Dual Melody mode)
-    - when: { z: down, gesture: hold }
+    - when: { z: down }
       main:
         name: Scale Select
-        description: Selects the quantisation scale index from 0 to 11 while the switch is held; the new scale takes effect on the next clock pulse
+        description: Selects the quantisation scale index from 0 to 11 while the switch is held down; the new scale takes effect on the next clock pulse
       x:
         name: Melody Profile
         description: Profile selection remains available outside the momentary scale-select gesture

--- a/releases/60_markov/info.yaml
+++ b/releases/60_markov/info.yaml
@@ -17,6 +17,12 @@ License: MIT
 date-created: 2026-05-30
 date-updated: 2026-08-04
 repository: https://github.com/TomWhitwell/Workshop_Computer/tree/main/releases/60_markov
+discussion: https://discord.com/channels/1210238368898879569/1510172134385647786
+
+contact:
+  email: andyuglifruit@hotmail.com
+  social:
+    github: https://github.com/uglifruit
 
 tags:
   - generative


### PR DESCRIPTION
Brings the Markov card metadata up to the current `info.yaml` schema and takes it out of draft, so it appears in the card listing instead of showing the "designer can approve by setting draft: false" banner.

Same conversion as #338 (Glitch). No firmware changes — `markov.uf2` is untouched.

## info.yaml

- `draft: false` — the card was hidden from the index
- Adds `License`, `repository`, `tags`, and an explicit `uf2:` entry pointing at `UF2/markov.uf2`
- Rewrites `summary` as a fuller operator overview using a `>-` block scalar
- Adds `type:` to every `panel` input/output
- Adds a `controls.switch` section describing the three switch positions
- Documents Dual Melody mode behaviour on the jacks it repurposes (CV In 2, Pulse Out 2, CV Out 2, Audio Out 2)
- `Language` now names the RP2040 SDK, matching the sibling cards

## README

While cross-checking the LED descriptions against `main.cpp` I found the scale table was wrong. The scale display is a straight `scale_index >> i` across LEDs 0–5, and ComputerCard numbers LEDs row-major (`0 1 / 2 3 / 4 5`), but the README documented a column-major reading — so 10 of the 12 diagrams didn't match what the hardware shows. All twelve rows are recomputed from the firmware and the caption now describes the real mapping.

The melody/percussion profile tables and the loop-length table were already correct — those displays genuinely are column-based — and are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)