### PR TITLE
Chorgan + OffAir: info.yaml conversion to new format, draft false

### DIFF
--- a/releases/91_chorgan/README.md
+++ b/releases/91_chorgan/README.md
@@ -233,4 +233,4 @@ V/oct lookup table (`voct_vals`) from [Utility Pair](https://github.com/chrisgjo
 
 Waveform morphing concept inspired by [Mutable Instruments Braids](https://mutable-instruments.net/modules/braids/) (Émilie Gillet).
 
-Licensed under [Creative Commons Attribution-ShareAlike 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
+Licensed under the [MIT License](https://opensource.org/licenses/MIT). The `voct_vals` lookup table retains its original licence from Utility Pair (MIT).

--- a/releases/91_chorgan/info.yaml
+++ b/releases/91_chorgan/info.yaml
@@ -1,11 +1,29 @@
+draft: false
 Name: Chorgan
-short-description: "Chorgan — 6-voice chord synthesizer with morphing timbre, chord extension presets, and built-in chord sequencer. Two modes: normal (detune/chorus) and slew (portamento chord changes). Inspired by the Music Thing Modular Chord Organ."
+short-description: Six-voice morphing chord synthesizer with extension presets and a built-in eight-slot chord sequencer
+summary: >-
+  Six-voice chord synthesizer with a built-in sequencer, inspired by the Music Thing Modular
+  Chord Organ. Knob X and CV In 1 set root pitch, Knob Y picks the interval above the root, and
+  four extension voices fill out the chord from the same harmonic world as that interval. The
+  Main knob morphs all six voices through pulse, sine, saw, sine, pulse. Audio In 1 adds
+  portamento glide and Audio In 2 shifts the voicing through octave inversions. Tap the switch
+  down to cycle extension presets, hold it a second to store a chord, and clock Pulse In 2 to
+  step through up to eight stored chords. Boot with the switch held down for slew mode, where
+  chord changes glide instead of detuning.
 Language: C++ (Pico SDK / ComputerCard)
 Creator: Andy Jenkinson (uglifruit)
 Version: 1.1.0
-Status: released
+Status: Released
+License: MIT
 date-created: 2026-06-21
-date-updated: 2026-06-24
+date-updated: 2026-08-04
+repository: https://github.com/TomWhitwell/Workshop_Computer/tree/main/releases/91_chorgan
+discussion: https://discord.com/channels/1210238368898879569/1518232991334137906
+
+contact:
+  email: andyuglifruit@hotmail.com
+  social:
+    github: https://github.com/uglifruit
 
 tags:
   - synthesizer
@@ -14,110 +32,126 @@ tags:
   - polyphonic
   - portamento
 
-summary: |
-  Six-voice morphing chord synthesizer with built-in chord sequencer.
-  Knob X and CV In 1 set root pitch; Knob Y selects interval above root (0–12 semitones).
-  Main knob morphs all six voices through sine, triangle, saw, and narrow pulse; CV In 2 offsets timbre.
-  Audio In 1 controls slew speed (0V=instant, +5V=approx 1 min glide). Audio In 2 shifts chord voicing through octave inversions (bipolar, +/-6 steps).
-  Tap Switch Down to cycle chord extension presets; hold one second to store a chord in the sequencer.
-  Pulse In 1 advances preset; Pulse In 2 recalls the next stored chord on rising edges.
-  Boot with Switch Down held for slew mode (portamento chord changes instead of detune).
+uf2:
+  - path: chorgan.uf2
+    name: Chorgan v1.1.0
 
 panel:
   inputs:
     - id: CVIn1
       name: Root Pitch CV
-      description: Root pitch 1V/oct (0V = C4), summed with Knob X
+      type: cv
+      description: Root pitch at 1V/oct with 0V as C4, summed with Knob X and applied uniformly to all six voices
     - id: CVIn2
       name: Timbre Offset CV
-      description: Bipolar offset to Main knob timbre position
+      type: cv
+      description: Bipolar offset to the Main knob timbre position; cannot push the timbre across a detune or slew zone boundary
     - id: AudioIn1
       name: Slew Speed CV
-      description: 0V=instant, +5V=approx 1 min glide; negative shortens slew in slew mode
+      type: audio
+      description: Portamento glide amount — 0V or unpatched is instant, +5V is roughly a one minute glide. In slew mode negative voltage shortens the zone rate
     - id: AudioIn2
       name: Chord Inversion CV
-      description: Bipolar +/-6 octave inversion steps; shifts lowest/highest voice up or down
+      type: audio
+      description: Bipolar octave inversions up to six steps each way, cycling the lowest voice up or the highest voice down. Affects the audio outputs only
     - id: PulseIn1
       name: Preset Advance
-      description: Rising edge advances chord extension preset
+      type: pulse
+      description: Rising edge advances the chord extension preset, and does not break an active chord override
     - id: PulseIn2
       name: Chord Recall Clock
-      description: Rising edge recalls next stored chord in sequencer
+      type: pulse
+      description: Rising edge recalls the next stored chord, wrapping at the end. Must be seen low once after boot before it responds
   outputs:
     - id: AudioOut1
       name: Six-Voice Mix
-      description: Six-voice chord mix output
+      type: audio
+      description: The full six-voice chord mix
     - id: AudioOut2
       name: Phase-Offset Mix
-      description: Same voices with per-voice phase offsets for stereo width
+      type: audio
+      description: The same six voices with per-voice phase offsets of 0 to 75 degrees for stereo width
     - id: PulseOut1
       name: Sub-Octave Square
-      description: Square wave one octave below root
+      type: pulse
+      description: Clean square wave one octave below the root
     - id: PulseOut2
       name: Chord Event PWM
-      description: PWM envelope resetting on each chord event
+      type: pulse
+      description: PWM square at root pitch, resetting to 50 percent duty on each chord event then ramping to 20 percent at the zone rate
     - id: CVOut1
       name: Voiced Pitch CV
-      description: Root pitch plus voiced interval (1V/oct)
+      type: cv
+      description: Root pitch plus the voiced interval at 1V/oct, clamped to ±5V and following the chord override
     - id: CVOut2
       name: Chord Event Ramp
-      description: Unipolar downward ramp (+5V to 0V) on each chord event
+      type: cv
+      description: Unipolar downward ramp from +5V to 0V on each chord event, tracking the Pulse Out 2 timing exactly
 
 controls:
+  switch:
+    up:
+      name: Detune Zone B
+      description: Selects the higher pair of detune levels (or slew rates in slew mode) — 10 cents clockwise of centre, 15 cents counter-clockwise
+    middle:
+      name: Detune Zone A
+      description: Selects the lower pair of detune levels (or slew rates in slew mode) — clean counter-clockwise of centre, 5 cents clockwise
+    down:
+      name: Preset Cycle / Store
+      description: Hold one second to store the current chord to the next sequencer slot. Held at power-on this selects slew mode instead
+    tap:
+      name: Cycle Preset
+      description: A tap under one second advances the chord extension preset for voices 3 to 6, six presets per interval
   knobs:
     - when: { z: middle }
       main:
-        name: Timbre
-        description: Morphs waveform of all six voices (pulse → sine → saw → sine → pulse)
+        name: Timbre / Detune Zone A
+        description: Morphs all six voices through pulse, sine, saw, sine, pulse. Counter-clockwise of centre is clean with a 250ms envelope, clockwise is 5 cents with a 100ms envelope
       x:
         name: Root Pitch
-        description: Root pitch from C3 to C6, summed with CV In 1
+        description: Sweeps the root from C3 to C6, summed with CV In 1
       y:
         name: Interval
-        description: Semitone interval between root and voice 2 (0–12)
+        description: Semitone interval between the root and voice 2, from 0 for unison to 12 for an octave
     - when: { z: up }
       main:
-        name: Timbre
-        description: Same timbre morph with detune zone selected by switch/knob quadrant
+        name: Timbre / Detune Zone B
+        description: Same timbre morph. Clockwise of centre is 10 cents with a 500ms envelope, counter-clockwise is 15 cents with a 3s envelope
       x:
         name: Root Pitch
-        description: Root pitch control
+        description: Sweeps the root from C3 to C6, summed with CV In 1
       y:
         name: Interval
-        description: Semitone interval control
-  switches:
-    - id: Z
-      up:
-        name: Detune Zone B
-        description: Higher detune level selected by knob quadrant
-      middle:
-        name: Detune Zone A
-        description: Lower detune level selected by knob quadrant
-      down:
-        name: Preset Cycle / Store
-        description: Short tap cycles preset; one-second hold stores current chord to sequencer
-
+        description: Semitone interval between the root and voice 2, from 0 for unison to 12 for an octave
   leds:
-    - when: { z: any }
-      display: list
+    - display: list
       items:
-        - id: LED0
-          name: Interval Position A
-          description: Part of interval position display across LEDs 0–4
-        - id: LED1
-          name: Store/Recall Bit A
-          description: Binary slot indicator during store/recall gestures
-        - id: LED2
-          name: Interval Position B
-        - id: LED3
-          name: Store/Recall Bit B
-        - id: LED4
-          name: Interval Position C
-        - id: LED5
-          name: Preset Brightness
-          description: Brightness indicates current extension preset (0–5)
+        - id: led0
+          name: Interval Position / Slot Bit 0
+          description: Part of the interval position display across LEDs 0 to 4; bit 0 of the slot number while storing; full bright while a chord is held
+        - id: led1
+          name: Interval Position / Recall Bit 0
+          description: Part of the interval position display; full bright while storing; bit 0 of the recalled slot while a chord is held
+        - id: led2
+          name: Interval Position / Slot Bit 1
+          description: Part of the interval position display across LEDs 0 to 4; bit 1 of the slot number while storing; full bright while a chord is held
+        - id: led3
+          name: Interval Position / Recall Bit 1
+          description: Part of the interval position display; full bright while storing; bit 1 of the recalled slot while a chord is held
+        - id: led4
+          name: Interval Position / Slot Bit 2
+          description: Part of the interval position display across LEDs 0 to 4; bit 2 of the slot number while storing; full bright while a chord is held
+        - id: led5
+          name: Preset Brightness / Recall Bit 2
+          description: Brightness indicates the current extension preset from 0 to 5; full bright while storing; bit 2 of the recalled slot while a chord is held
 
 host:
   notes: |
-    Slew mode boots when Switch Down is held at power-on until LEDs flash.
-    Up to eight chords can be stored; storing more than eight overwrites from the beginning.
+    Slew mode boots when the switch is held down at power-on until the LEDs flash — all on, then
+    all off, around 200ms. Detune is disabled and chord changes glide instead, with per-voice
+    portamento rates of instant, 200ms, 700ms or 3s set by the same four zones.
+
+    The sequencer stores up to eight chords, each capturing pitch, interval and preset. Storing
+    more than eight overwrites from the beginning. A recalled chord is released by moving Knob X
+    or CV In 1 more than one semitone from where they sat at recall, or by moving Knob Y to a
+    different step.

--- a/releases/95_offair2/README.md
+++ b/releases/95_offair2/README.md
@@ -245,6 +245,8 @@ personal and educational use only. *Protect and Survive* material is Crown Copyr
 redistribution. If you build a derivative work for release, replace these recordings
 with material you have the rights to use.
 
-Licensed under
-[Creative Commons Attribution-ShareAlike 4.0](https://creativecommons.org/licenses/by-sa/4.0/)
-— except where third-party copyright applies as noted above.
+The firmware and conversion tooling are licensed under the
+[MIT License](https://opensource.org/licenses/MIT) — except where third-party copyright
+applies as noted above. The baked-in Station recordings are **not** covered by that licence
+and are not redistributable; replace them with material you have the rights to use if you
+release a derivative work.

--- a/releases/95_offair2/info.yaml
+++ b/releases/95_offair2/info.yaml
@@ -1,13 +1,29 @@
+draft: false
 Name: OffAir
-short-description: "OffAir — AM/Shortwave/Longwave radio simulator. Tune between two Stations and interference with authentic heterodyne whistles, SSB pitch-shift detuning, AM envelope detection, swelling per-band static, and triggerable Insta-ference one-shots. Baked recordings or live audio inputs become the Stations."
+short-description: AM/Shortwave/Longwave radio simulator with heterodyne whistles, SSB detuning and swelling static
+summary: >-
+  Tune across a virtual shortwave band the way you tune a real receiver. Two Stations and three
+  interference signals are scattered across the dial and re-randomised on every band change.
+  Approaching a Station you hear a sliding heterodyne whistle, the audio pulls into tune and the
+  static ducks away; off-tune it frequency-shifts on SW and LW or distorts on AM. Knob X sets IF
+  bandwidth and brightness, Knob Y the noise floor. Tap the switch down to cycle AM, SW and LW.
+  Hold the switch up for dead air in baked-in mode, or a Pulse In 1-keyed morse Station 2 in
+  audio-input mode. Pulse In 2 fires curated Insta-ference one-shots. Boot with the switch held
+  down to swap the live inputs for baked recordings and make it self-contained.
 Language: C++ (Pico SDK / ComputerCard)
 Creator: Andy Jenkinson (uglifruit)
 Version: 1.0.1
-Status: released
-License: CC BY-SA 4.0
+Status: Released
+License: MIT
 date-created: 2026-06-27
-date-updated: 2026-07-02
-Repository: https://github.com/uglifruit/Workshop_Computer
+date-updated: 2026-08-04
+repository: https://github.com/TomWhitwell/Workshop_Computer/tree/main/releases/95_offair2
+discussion: https://discord.com/channels/1210238368898879569/1520467972089577623
+
+contact:
+  email: andyuglifruit@hotmail.com
+  social:
+    github: https://github.com/uglifruit
 
 tags:
   - radio
@@ -16,43 +32,45 @@ tags:
   - effect
   - generative
 
-summary: |
-  Tune across a virtual shortwave band with the Main knob. Two Stations (live audio
-  inputs, or baked recordings in baked-in audio mode) plus three interference signals
-  are scattered across the dial and re-randomised on each band change. Approaching a
-  Station you hear a sliding heterodyne whistle, the audio pulls into tune and the
-  static ducks away; off-tune it pitch-shifts (SW/LW) or distorts (AM). Knob X sets IF
-  bandwidth/brightness, Knob Y the noise level. Tap Switch Down to cycle AM/SW/LW.
-  Hold Switch Up for dead-air (baked-in mode) or a Pulse In 1-keyed morse Station 2
-  (audio-input mode). Pulse In 2 fires curated "Insta-ference" one-shots.
+uf2:
+  - path: offair.uf2
+    name: OffAir v1.0.1
 
 panel:
   inputs:
     - id: AudioIn1
       name: Station 1 In
       type: audio
-      description: Station 1 source (live audio, in audio-input mode)
+      description: Station 1 source in audio-input mode; replaced by a baked recording in baked-in audio mode
     - id: AudioIn2
       name: Station 2 In
       type: audio
-      description: Station 2 source (live audio, in audio-input mode)
+      description: Station 2 source in audio-input mode; becomes a keyed morse tone while the switch is held up
     - id: CVIn1
       name: Tuner
       type: cv
-      description: Tuning offset added to the Main knob (1:1, ±5V ≈ ±half the dial)
+      description: Tuning offset added 1:1 to the Main knob, where ±5V covers roughly half the dial each way
     - id: CVIn2
       name: Noise
       type: cv
-      description: Adds to the Knob Y noise level (voltage-controlled static)
+      description: Adds to the Knob Y noise level for voltage-controlled static
     - id: PulseIn1
       name: Shuffle Signals
       type: pulse
-      description: Rising edge re-randomises the Station/interference layout. In audio-input mode with Switch Up it is the Morse In key instead.
+      description: Rising edge re-randomises the Station and interference layout. In audio-input mode with the switch held up it becomes the morse key instead
     - id: PulseIn2
       name: Insta-ference
       type: pulse
-      description: Rising edge fires a one-shot event from the curated Insta-ference bank
+      description: Rising edge fires a one-shot from the curated Insta-ference bank, restarting if retriggered
   outputs:
+    - id: AudioOut1
+      name: Output
+      type: audio
+      description: Full mix of tuned audio, whistles, static and Insta-ference
+    - id: AudioOut2
+      name: Just Noise
+      type: audio
+      description: Noise and static only, for processing independently
     - id: CVOut1
       name: Signal Strength
       type: cv
@@ -60,56 +78,69 @@ panel:
     - id: CVOut2
       name: Station 1 CV Offset
       type: cv
-      description: Station 1's offset from the Main knob — slew into CV In 1 to tune onto Station 1
-    - id: AudioOut1
-      name: Output
-      type: audio
-      description: Full mix — tuned audio, whistles, static, Insta-ference
-    - id: AudioOut2
-      name: Just Noise
-      type: audio
-      description: Noise / static only
+      description: Station 1's offset from the Main knob — patch back into CV In 1, through a slew or direct, to hunt or lock onto Station 1
     - id: PulseOut1
       name: Station 1 Tuned Gate
       type: pulse
-      description: HIGH while tuned to Station 1
+      description: Gate high while tuned to Station 1
     - id: PulseOut2
       name: Station 2 Tuned Gate
       type: pulse
-      description: HIGH while tuned to Station 2
+      description: Gate high while tuned to Station 2
 
 controls:
+  switch:
+    up:
+      name: Dead Air / Morse
+      description: Held. In baked-in audio mode this mutes both Stations while the interference and their CV and gate outputs continue; in audio-input mode Station 2 becomes a 600Hz morse tone keyed by Pulse In 1
+    middle:
+      name: Normal
+      description: Standard tuning behaviour
+    down:
+      name: Baked-in Audio Boot
+      description: Held at power-on until all six LEDs flash, this replaces the live inputs with baked recordings for a self-contained radio
+    tap:
+      name: Cycle Band
+      description: A tap cycles AM to SW to LW, re-randomising the dial layout each time
   knobs:
-    - when: { z: any }
-      main:
+    - main:
         name: Tuning
-        description: Scans across the dial (sums with CV In 1)
+        description: Scans across the dial, summed with CV In 1
       x:
         name: Brightness
-        description: IF bandwidth — capture width + audio brightness (CCW narrow/muffled, CW wide/bright)
+        description: IF bandwidth — sets both the Station capture width and the audio brightness, from narrow and muffled counter-clockwise to wide and bright clockwise
       y:
         name: Noise Level
-        description: Static floor (silent fully CCW); slowly swells and swishes, heaviest on LW
-    - when: { z: down, gesture: momentary }
-      main:
-        name: Cycle Band
-        description: Tap to cycle AM → SW → LW, re-randomising the layout each time
-    - when: { z: up, gesture: hold }
-      main:
-        name: Dead-air / Morse
-        description: Baked-in mode — mutes both Stations (static remains). Audio-input mode — Station 2 becomes a ~600Hz morse tone keyed by Pulse In 1.
+        description: Static floor, silent fully counter-clockwise. Swells and swishes on its own, heaviest on LW, and ducks away when you tune onto a Station
   leds:
-    - when: { z: any }
-      display: list
+    - display: list
       items:
-        - id: LED0
-          name: Station 1 signal strength
-        - id: LED1
-          name: Station 2 signal strength
-        - id: LED2
-          name: SW band
-          description: Lit on SW (with LED3 off = AM, LED3 on = LW)
-        - id: LED3
-          name: LW band
-        - id: LED5
-          name: Tuning position
+        - id: led0
+          name: Station 1 Signal Strength
+          description: Brightness rises as you tune onto Station 1
+        - id: led1
+          name: Station 2 Signal Strength
+          description: Brightness rises as you tune onto Station 2
+        - id: led2
+          name: SW Band
+          description: Lit on SW. With LED3 both off the band is AM
+        - id: led3
+          name: LW Band
+          description: Lit on LW. With LED2 both off the band is AM
+        - id: led4
+          name: Unused
+          description: Not used in this firmware
+        - id: led5
+          name: Tuning Position
+          description: Indicates the current position across the dial
+
+host:
+  notes: |
+    Audio-input mode boots with the switch in any position other than down, or released within
+    the first 200ms, and the two live audio inputs become Station 1 and 2. Baked-in audio mode
+    boots with the switch held down until all six LEDs flash, replacing the live inputs with
+    baked recordings.
+
+    The baked audio lives in clips.h, generated from your own source files by convert_clips.py —
+    the source audio is not included in this repo. See the README for the conversion workflow and
+    the roughly 2MB flash budget.


### PR DESCRIPTION
Brings `91_chorgan` and `95_offair2` up to the current `info.yaml` schema, matching the Glitch (#338) and Markov (#339) conversions. Both cards now validate with **0 errors, 0 warnings** under `tools/sitegen`; on `main` they currently report 5 and 9 warnings respectively.

No firmware changes — both `.uf2` files are untouched and versions are unchanged (Chorgan 1.1.0, OffAir 1.0.1).

## Shared

- `draft: false`, and `Status: Released` (both were lowercase `released`)
- Unquoted `short-description`; `summary` rewritten as a `>-` block scalar
- Adds `discussion` (Discord thread), `contact`, `repository`, and an explicit `uf2:` entry
- Adds `type:` to every panel input/output
- Replaces the legacy `when.z: any` and `when.gesture` syntax — an omitted `when` already covers every switch position, and tap actions belong in `controls.switch.tap`
- LED ids lowercased; every item now carries the schema-required `name`

## Chorgan

The old file had a `switches:` list, which isn't in the schema at all (`controls` permits only `knobs`, `switch`, `leds`). That's replaced with a `switch:` object, with the tap-to-cycle-preset action moved into `switch.tap`.

Adds `License: MIT`, which was absent entirely. The borrowed `voct_vals` table comes from Utility Pair, which is MIT, so there's no conflict.

The store and recall LED displays are now documented, verified against `main.cpp` — storing lights LEDs 1/3/5 full with the slot number in 0/2/4, and recall inverts that.

## OffAir

LED4 was omitted from the old file; it's now documented as unused, which `main.cpp:754` confirms by explicitly holding it at 0.

Adds `License: MIT` for the firmware and conversion tooling.

## READMEs

Both relicensed to MIT to match. OffAir keeps its explicit carve-out: the baked-in Station recordings are Crown Copyright and BBC material, are not covered by the firmware licence, and are not redistributable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)