### PR TITLE
OffAir (95_offair2): info.yaml conversion to new format, draft false

### DIFF
--- a/releases/95_offair2/README.md
+++ b/releases/95_offair2/README.md
@@ -245,6 +245,8 @@ personal and educational use only. *Protect and Survive* material is Crown Copyr
 redistribution. If you build a derivative work for release, replace these recordings
 with material you have the rights to use.
 
-Licensed under
-[Creative Commons Attribution-ShareAlike 4.0](https://creativecommons.org/licenses/by-sa/4.0/)
-— except where third-party copyright applies as noted above.
+The firmware and conversion tooling are licensed under the
+[MIT License](https://opensource.org/licenses/MIT) — except where third-party copyright
+applies as noted above. The baked-in Station recordings are **not** covered by that licence
+and are not redistributable; replace them with material you have the rights to use if you
+release a derivative work.

--- a/releases/95_offair2/info.yaml
+++ b/releases/95_offair2/info.yaml
@@ -1,13 +1,29 @@
+draft: false
 Name: OffAir
-short-description: "OffAir — AM/Shortwave/Longwave radio simulator. Tune between two Stations and interference with authentic heterodyne whistles, SSB pitch-shift detuning, AM envelope detection, swelling per-band static, and triggerable Insta-ference one-shots. Baked recordings or live audio inputs become the Stations."
+short-description: AM/Shortwave/Longwave radio simulator with heterodyne whistles, SSB detuning and swelling static
+summary: >-
+  Tune across a virtual shortwave band the way you tune a real receiver. Two Stations and three
+  interference signals are scattered across the dial and re-randomised on every band change.
+  Approaching a Station you hear a sliding heterodyne whistle, the audio pulls into tune and the
+  static ducks away; off-tune it frequency-shifts on SW and LW or distorts on AM. Knob X sets IF
+  bandwidth and brightness, Knob Y the noise floor. Tap the switch down to cycle AM, SW and LW.
+  Hold the switch up for dead air in baked-in mode, or a Pulse In 1-keyed morse Station 2 in
+  audio-input mode. Pulse In 2 fires curated Insta-ference one-shots. Boot with the switch held
+  down to swap the live inputs for baked recordings and make it self-contained.
 Language: C++ (Pico SDK / ComputerCard)
 Creator: Andy Jenkinson (uglifruit)
 Version: 1.0.1
-Status: released
-License: CC BY-SA 4.0
+Status: Released
+License: MIT
 date-created: 2026-06-27
-date-updated: 2026-07-02
-Repository: https://github.com/uglifruit/Workshop_Computer
+date-updated: 2026-08-04
+repository: https://github.com/TomWhitwell/Workshop_Computer/tree/main/releases/95_offair2
+discussion: https://discord.com/channels/1210238368898879569/1520467972089577623
+
+contact:
+  email: andyuglifruit@hotmail.com
+  social:
+    github: https://github.com/uglifruit
 
 tags:
   - radio
@@ -16,43 +32,45 @@ tags:
   - effect
   - generative
 
-summary: |
-  Tune across a virtual shortwave band with the Main knob. Two Stations (live audio
-  inputs, or baked recordings in baked-in audio mode) plus three interference signals
-  are scattered across the dial and re-randomised on each band change. Approaching a
-  Station you hear a sliding heterodyne whistle, the audio pulls into tune and the
-  static ducks away; off-tune it pitch-shifts (SW/LW) or distorts (AM). Knob X sets IF
-  bandwidth/brightness, Knob Y the noise level. Tap Switch Down to cycle AM/SW/LW.
-  Hold Switch Up for dead-air (baked-in mode) or a Pulse In 1-keyed morse Station 2
-  (audio-input mode). Pulse In 2 fires curated "Insta-ference" one-shots.
+uf2:
+  - path: offair.uf2
+    name: OffAir v1.0.1
 
 panel:
   inputs:
     - id: AudioIn1
       name: Station 1 In
       type: audio
-      description: Station 1 source (live audio, in audio-input mode)
+      description: Station 1 source in audio-input mode; replaced by a baked recording in baked-in audio mode
     - id: AudioIn2
       name: Station 2 In
       type: audio
-      description: Station 2 source (live audio, in audio-input mode)
+      description: Station 2 source in audio-input mode; becomes a keyed morse tone while the switch is held up
     - id: CVIn1
       name: Tuner
       type: cv
-      description: Tuning offset added to the Main knob (1:1, ±5V ≈ ±half the dial)
+      description: Tuning offset added 1:1 to the Main knob, where ±5V covers roughly half the dial each way
     - id: CVIn2
       name: Noise
       type: cv
-      description: Adds to the Knob Y noise level (voltage-controlled static)
+      description: Adds to the Knob Y noise level for voltage-controlled static
     - id: PulseIn1
       name: Shuffle Signals
       type: pulse
-      description: Rising edge re-randomises the Station/interference layout. In audio-input mode with Switch Up it is the Morse In key instead.
+      description: Rising edge re-randomises the Station and interference layout. In audio-input mode with the switch held up it becomes the morse key instead
     - id: PulseIn2
       name: Insta-ference
       type: pulse
-      description: Rising edge fires a one-shot event from the curated Insta-ference bank
+      description: Rising edge fires a one-shot from the curated Insta-ference bank, restarting if retriggered
   outputs:
+    - id: AudioOut1
+      name: Output
+      type: audio
+      description: Full mix of tuned audio, whistles, static and Insta-ference
+    - id: AudioOut2
+      name: Just Noise
+      type: audio
+      description: Noise and static only, for processing independently
     - id: CVOut1
       name: Signal Strength
       type: cv
@@ -60,56 +78,69 @@ panel:
     - id: CVOut2
       name: Station 1 CV Offset
       type: cv
-      description: Station 1's offset from the Main knob — slew into CV In 1 to tune onto Station 1
-    - id: AudioOut1
-      name: Output
-      type: audio
-      description: Full mix — tuned audio, whistles, static, Insta-ference
-    - id: AudioOut2
-      name: Just Noise
-      type: audio
-      description: Noise / static only
+      description: Station 1's offset from the Main knob — patch back into CV In 1, through a slew or direct, to hunt or lock onto Station 1
     - id: PulseOut1
       name: Station 1 Tuned Gate
       type: pulse
-      description: HIGH while tuned to Station 1
+      description: Gate high while tuned to Station 1
     - id: PulseOut2
       name: Station 2 Tuned Gate
       type: pulse
-      description: HIGH while tuned to Station 2
+      description: Gate high while tuned to Station 2
 
 controls:
+  switch:
+    up:
+      name: Dead Air / Morse
+      description: Held. In baked-in audio mode this mutes both Stations while the interference and their CV and gate outputs continue; in audio-input mode Station 2 becomes a 600Hz morse tone keyed by Pulse In 1
+    middle:
+      name: Normal
+      description: Standard tuning behaviour
+    down:
+      name: Baked-in Audio Boot
+      description: Held at power-on until all six LEDs flash, this replaces the live inputs with baked recordings for a self-contained radio
+    tap:
+      name: Cycle Band
+      description: A tap cycles AM to SW to LW, re-randomising the dial layout each time
   knobs:
-    - when: { z: any }
-      main:
+    - main:
         name: Tuning
-        description: Scans across the dial (sums with CV In 1)
+        description: Scans across the dial, summed with CV In 1
       x:
         name: Brightness
-        description: IF bandwidth — capture width + audio brightness (CCW narrow/muffled, CW wide/bright)
+        description: IF bandwidth — sets both the Station capture width and the audio brightness, from narrow and muffled counter-clockwise to wide and bright clockwise
       y:
         name: Noise Level
-        description: Static floor (silent fully CCW); slowly swells and swishes, heaviest on LW
-    - when: { z: down, gesture: momentary }
-      main:
-        name: Cycle Band
-        description: Tap to cycle AM → SW → LW, re-randomising the layout each time
-    - when: { z: up, gesture: hold }
-      main:
-        name: Dead-air / Morse
-        description: Baked-in mode — mutes both Stations (static remains). Audio-input mode — Station 2 becomes a ~600Hz morse tone keyed by Pulse In 1.
+        description: Static floor, silent fully counter-clockwise. Swells and swishes on its own, heaviest on LW, and ducks away when you tune onto a Station
   leds:
-    - when: { z: any }
-      display: list
+    - display: list
       items:
-        - id: LED0
-          name: Station 1 signal strength
-        - id: LED1
-          name: Station 2 signal strength
-        - id: LED2
-          name: SW band
-          description: Lit on SW (with LED3 off = AM, LED3 on = LW)
-        - id: LED3
-          name: LW band
-        - id: LED5
-          name: Tuning position
+        - id: led0
+          name: Station 1 Signal Strength
+          description: Brightness rises as you tune onto Station 1
+        - id: led1
+          name: Station 2 Signal Strength
+          description: Brightness rises as you tune onto Station 2
+        - id: led2
+          name: SW Band
+          description: Lit on SW. With LED3 both off the band is AM
+        - id: led3
+          name: LW Band
+          description: Lit on LW. With LED2 both off the band is AM
+        - id: led4
+          name: Unused
+          description: Not used in this firmware
+        - id: led5
+          name: Tuning Position
+          description: Indicates the current position across the dial
+
+host:
+  notes: |
+    Audio-input mode boots with the switch in any position other than down, or released within
+    the first 200ms, and the two live audio inputs become Station 1 and 2. Baked-in audio mode
+    boots with the switch held down until all six LEDs flash, replacing the live inputs with
+    baked recordings.
+
+    The baked audio lives in clips.h, generated from your own source files by convert_clips.py —
+    the source audio is not included in this repo. See the README for the conversion workflow and
+    the roughly 2MB flash budget.


### PR DESCRIPTION
Brings `95_offair2` up to the current `info.yaml` schema, matching the Glitch (#338) and Markov (#339) conversions. Validates with **0 errors, 0 warnings** under `tools/sitegen`; it reported 9 warnings before.

No firmware changes — `offair.uf2` is untouched and the version stays 1.0.1.

Split out from #340, which covered two release directories and tripped the `multiple-release-directories` rule. Chorgan is now #341.

## Changes

- `draft: false`, and `Status: Released` (was lowercase `released`)
- Replaces the legacy `when.z: any` and `when.gesture` syntax — an omitted `when` covers every switch position, and tap actions belong in `controls.switch.tap`
- Unquoted `short-description`; `summary` rewritten as a `>-` block scalar
- Adds `discussion` (Discord thread), `contact`, and an explicit `uf2:` entry; `Repository` corrected to lowercase `repository`
- LED ids lowercased; every item now carries the schema-required `name`
- Documents LED4, previously omitted from the list — `main.cpp:754` explicitly holds it at 0, so it's recorded as unused rather than left as a gap

## Licence

Set to MIT for the firmware and conversion tooling.

The README keeps its existing carve-out, which matters here: the baked-in Station recordings are *Protect and Survive* (Crown Copyright) and the *Shipping Forecast* (© BBC). Those aren't covered by the firmware licence and aren't redistributable — anyone building a derivative for release should swap in material they have the rights to use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)