### PR TITLE
Updated broken links

### DIFF
--- a/releases/101_Gnarly_C1ZZL3/C1ZZL3_Gnarly_quick_reference.txt
+++ b/releases/101_Gnarly_C1ZZL3/C1ZZL3_Gnarly_quick_reference.txt
@@ -72,10 +72,10 @@ CC27: oscillator 1 phase distortion for eight-knob controllers
 Web MIDI
 --------
 Hosted editor after deployment:
-https://tomwhitwell.github.io/Workshop_Computer/programs/101-gnarly-c1zzl3/web/index.html
+https://computer.musicthing.co.uk/programs/101-gnarly-c1zzl3/web/index.html
 
 Hosted import lab after deployment:
-https://tomwhitwell.github.io/Workshop_Computer/programs/101-gnarly-c1zzl3/web/import/index.html
+https://computer.musicthing.co.uk/programs/101-gnarly-c1zzl3/web/import/index.html
 
 Run editor:
 python3 -m http.server 5177 --directory web

--- a/releases/101_Gnarly_C1ZZL3/CARD_README.md
+++ b/releases/101_Gnarly_C1ZZL3/CARD_README.md
@@ -130,7 +130,7 @@ MIDI CC controls:
 Hosted editor path after Workshop deployment:
 
 ```text
-https://tomwhitwell.github.io/Workshop_Computer/programs/101-gnarly-c1zzl3/web/index.html
+https://computer.musicthing.co.uk/programs/101-gnarly-c1zzl3/web/index.html
 ```
 
 The editor can load to RAM, save envelope-only changes, save full sound presets,

--- a/releases/101_Gnarly_C1ZZL3/README.md
+++ b/releases/101_Gnarly_C1ZZL3/README.md
@@ -155,7 +155,7 @@ The C1ZZL3 Envelope Lab has a hidden Developer-mode MIDI CC Test Suite for check
 Hosted editor path after Workshop deployment:
 
 ```text
-https://tomwhitwell.github.io/Workshop_Computer/programs/101-gnarly-c1zzl3/web/index.html
+https://computer.musicthing.co.uk/programs/101-gnarly-c1zzl3/web/index.html
 ```
 
 Local editor from this release folder:
@@ -177,7 +177,7 @@ Use Chrome or another browser with Web MIDI and SysEx support. When Web MIDI con
 Hosted import lab path after Workshop deployment:
 
 ```text
-https://tomwhitwell.github.io/Workshop_Computer/programs/101-gnarly-c1zzl3/web/import/index.html
+https://computer.musicthing.co.uk/programs/101-gnarly-c1zzl3/web/import/index.html
 ```
 
 Local import lab from this release folder:

--- a/releases/101_Gnarly_C1ZZL3/info.yaml
+++ b/releases/101_Gnarly_C1ZZL3/info.yaml
@@ -14,7 +14,7 @@ Version: "Gnarly protocol v11 stable"
 Status: Beta - stable in single-developer testing
 License: MIT
 date-created: 2026-07-22
-Editor: https://tomwhitwell.github.io/Workshop_Computer/programs/101-gnarly-c1zzl3/web/index.html
+Editor: web
 
 tags:
   - synth

--- a/releases/101_Gnarly_C1ZZL3/web/app.js
+++ b/releases/101_Gnarly_C1ZZL3/web/app.js
@@ -71,8 +71,8 @@ const CZ_IMPORT_HANDOFF_KEY = "c1zzl3-full-dual-oscillators-import-draft";
 const CZ_IMPORT_QUEUE_KEY = "c1zzl3-full-dual-oscillators-import-queue";
 const ENVELOPE_LAB_HEARTBEAT_KEY = "c1zzl3-full-dual-oscillators-envelope-lab-heartbeat";
 const HANDOFF_CHANNEL_NAME = "c1zzl3-full-dual-oscillators-handoff";
-const HOSTED_EDITOR_URL = "https://tomwhitwell.github.io/Workshop_Computer/programs/101-gnarly-c1zzl3/web/index.html";
-const HOSTED_IMPORT_LAB_URL = "https://tomwhitwell.github.io/Workshop_Computer/programs/101-gnarly-c1zzl3/web/import/";
+const HOSTED_EDITOR_URL = "https://computer.musicthing.co.uk/programs/101-gnarly-c1zzl3/web/index.html";
+const HOSTED_IMPORT_LAB_URL = "https://computer.musicthing.co.uk/programs/101-gnarly-c1zzl3/web/import/";
 const LOCAL_IMPORT_LAB_URL = "import/index.html";
 
 let presets = loadPresets();


### PR DESCRIPTION
web editor link in info.yaml went to a 404 link, hopefully this has fixed things