### PR TITLE
make web editors that are in-repo work with local dev

### DIFF
--- a/documentation/metadata-site-development.md
+++ b/documentation/metadata-site-development.md
@@ -50,7 +50,9 @@ is part of the valid deployment path.
 npm run dev
 ```
 
-The command first performs a complete build, then serves the generated site at <http://localhost:5173/>.
+The command first performs a complete preview build, then serves the generated site at <http://localhost:5173/>.
+
+Copied web-editor links use that local origin (`http://localhost:5173/programs/<slug>/web/…`) so the assets served by Vite open instead of the production Pages URL. External `https://…` Editor values are unchanged. Production and CI builds keep the public base described above.
 
 While it is running, the development server watches:
 

--- a/tools/sitegen/package.json
+++ b/tools/sitegen/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "prebuild": "npm run check-curation",
     "build": "node ./src/build.js",
-    "dev": "npm run build && vite --config vite.config.js",
+    "dev": "npm run build -- --preview && vite --config vite.config.js",
     "validate-info": "node ./src/validate/cli.js",
     "check-curation": "node ./src/curation/cli.js check",
     "sync-curation": "node ./src/curation/cli.js sync",

--- a/tools/sitegen/src/build.js
+++ b/tools/sitegen/src/build.js
@@ -5,7 +5,7 @@ import { build as esbuild } from 'esbuild';
 import { makeRawUrl as makeRawUrlExternal } from './links.js';
 import { renderLayout } from './render/layout.js';
 import { discoverRelease as discoverReleaseMod } from './discover/release.js';
-import { githubPagesBase, copyWebAssets } from './discover/webEditor.js';
+import { resolveSiteBase, copyWebAssets } from './discover/webEditor.js';
 import { getInfoYamlSchemaAdapter } from './schema/schemaAdapter.js';
 import { infoYamlJsonSchema } from './schema/infoYamlJsonSchema.js';
 import { renderCardArticle, renderReadmeAndDocs } from './render/cardPage.js';
@@ -38,16 +38,11 @@ const DEFAULT_BRANCH = 'main';
 // available for an explicit preview override.
 const REPO = process.env.SITE_REPOSITORY || process.env.GITHUB_REPOSITORY || DEFAULT_REPO;
 const BRANCH = process.env.SITE_REF || process.env.GITHUB_SHA || process.env.GITHUB_REF_NAME || DEFAULT_BRANCH;
-const SITE_BASE = (() => {
-  const configured = String(process.env.SITE_BASE_URL || '').trim();
-  if (!configured) return githubPagesBase(REPO);
-  const url = new URL(configured);
-  if (!/^https?:$/.test(url.protocol)) throw new Error('SITE_BASE_URL must be an HTTP(S) URL.');
-  url.search = '';
-  url.hash = '';
-  if (!url.pathname.endsWith('/')) url.pathname += '/';
-  return url.href;
-})();
+const SITE_BASE = resolveSiteBase({
+  configured: process.env.SITE_BASE_URL,
+  preview: process.argv.includes('--preview'),
+  repoSlug: REPO,
+});
 const schemaAdapter = getInfoYamlSchemaAdapter();
 
 

--- a/tools/sitegen/src/discover/webEditor.js
+++ b/tools/sitegen/src/discover/webEditor.js
@@ -5,12 +5,33 @@ import { normalizeYamlKey } from '../utils/strings.js';
 const SKIP_DIRS = new Set(['node_modules', '.git', '.github']);
 const SKIP_FILES = new Set(['package-lock.json', 'tsconfig.json', 'vite.config.ts', 'vite.config.js']);
 const LOCAL_EDITOR_DIRS = new Set(['web', 'dist']);
+const LOCAL_PREVIEW_BASE = 'http://localhost:5173/';
 
 /** GitHub Pages base URL for a user/org project site. */
 export function githubPagesBase(repoSlug) {
   const [owner, name] = String(repoSlug || '').split('/');
   if (!owner || !name) return 'https://tomwhitwell.github.io/Workshop_Computer/';
   return `https://${owner.toLowerCase()}.github.io/${name}/`;
+}
+
+/**
+ * Public site origin used for copied (local) web-editor links.
+ * Preview builds (`npm run dev`) pin those links to the Vite origin so they
+ * stay on localhost instead of the production Pages URL. SITE_BASE_URL still
+ * wins when set, including during a preview build.
+ */
+export function resolveSiteBase({ configured = '', preview = false, repoSlug = '' } = {}) {
+  const value = String(configured || '').trim();
+  if (value) {
+    const url = new URL(value);
+    if (!/^https?:$/.test(url.protocol)) throw new Error('SITE_BASE_URL must be an HTTP(S) URL.');
+    url.search = '';
+    url.hash = '';
+    if (!url.pathname.endsWith('/')) url.pathname += '/';
+    return url.href;
+  }
+  if (preview) return LOCAL_PREVIEW_BASE;
+  return githubPagesBase(repoSlug);
 }
 
 function normalizeRelFolder(loc) {

--- a/tools/sitegen/src/utils/previewWeb.js
+++ b/tools/sitegen/src/utils/previewWeb.js
@@ -35,7 +35,7 @@ export function resolvePreviewWebConfig(raw, { slug = 'new-card', discoveredWeb 
   if (editor) return { mode: 'none', editorUrl: '', siteSubdir: 'web', entry: '' };
 
   if (discoveredWeb?.mode === 'local' && discoveredWeb.editorUrl) {
-    return entry ? localConfig(slug, entry) : { ...discoveredWeb };
+    return localConfig(slug, entry || discoveredWeb.entry || 'index.html');
   }
   if (discoveredWeb?.mode === 'external' && discoveredWeb.editorUrl) return { ...discoveredWeb };
   return { mode: 'none', editorUrl: '', siteSubdir: 'web', entry: '' };

--- a/tools/sitegen/test/discovery.test.js
+++ b/tools/sitegen/test/discovery.test.js
@@ -8,7 +8,7 @@ import { discoverRelease } from '../src/discover/release.js';
 import { discoverDocs } from '../src/discover/docs.js';
 import { compareFirmwareCandidates, curateUf2Downloads } from '../src/discover/downloads.js';
 import { discoverCustomPanels, validateCustomPanelReferences } from '../src/discover/customPanels.js';
-import { copyWebAssets, resolveWebConfig } from '../src/discover/webEditor.js';
+import { copyWebAssets, resolveSiteBase, resolveWebConfig } from '../src/discover/webEditor.js';
 
 async function fixture(t) {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'workshop-sitegen-'));
@@ -81,6 +81,25 @@ test('document and web discovery copy only publishable assets', async t => {
   assert.ok(await fs.stat(path.join(output, 'web', 'assets', 'app.js')));
   await assert.rejects(fs.stat(path.join(output, 'web', 'src', 'source.js')));
   await assert.rejects(fs.stat(path.join(output, 'web', 'package.json')));
+});
+
+test('site base uses localhost for preview builds and Pages URLs otherwise', () => {
+  assert.equal(
+    resolveSiteBase({ preview: true }),
+    'http://localhost:5173/',
+  );
+  assert.equal(
+    resolveSiteBase({ repoSlug: 'DessertPlanet/Workshop_Computer' }),
+    'https://dessertplanet.github.io/Workshop_Computer/',
+  );
+  assert.equal(
+    resolveSiteBase({ configured: 'https://computer.musicthing.co.uk', preview: true }),
+    'https://computer.musicthing.co.uk/',
+  );
+  assert.throws(
+    () => resolveSiteBase({ configured: 'ftp://example.test/' }),
+    /SITE_BASE_URL must be an HTTP\(S\) URL/,
+  );
 });
 
 test('web editors reject traversal, unsafe protocols, and symlinks', async t => {

--- a/tools/sitegen/test/preview-web.test.js
+++ b/tools/sitegen/test/preview-web.test.js
@@ -9,14 +9,14 @@ test('author preview web metadata shows, updates, and hides the editor action', 
   assert.equal(resolvePreviewWebConfig({ Editor: 'none' }).editorUrl, '');
 });
 
-test('existing-card previews retain auto-discovered editors and reflect entry edits', () => {
+test('existing-card previews keep auto-discovered local editors on the preview origin', () => {
   const discoveredWeb = {
     mode: 'local',
     editorUrl: 'https://pages.test/programs/42-fixture/web/index.html',
     siteSubdir: 'web',
     entry: 'index.html',
   };
-  assert.equal(resolvePreviewWebConfig({}, { slug: '42-fixture', discoveredWeb }).editorUrl, discoveredWeb.editorUrl);
+  assert.equal(resolvePreviewWebConfig({}, { slug: '42-fixture', discoveredWeb }).editorUrl, '../programs/42-fixture/web/index.html');
   assert.equal(resolvePreviewWebConfig({ 'web-entry': 'manager.html' }, { slug: '42-fixture', discoveredWeb }).editorUrl, '../programs/42-fixture/web/manager.html');
   assert.equal(resolvePreviewWebConfig({ Editor: 'none' }, { slug: '42-fixture', discoveredWeb }).editorUrl, '');
 });

--- a/tools/sitegen/vite.config.js
+++ b/tools/sitegen/vite.config.js
@@ -27,19 +27,20 @@ function rebuildSite() {
   let server;
 
   function buildArgs(files) {
-    if (files.length !== 1) return ['run', 'build'];
+    const preview = ['--prefix', 'tools/sitegen', 'run', 'build', '--', '--preview'];
+    if (files.length !== 1) return preview;
     const relative = path.relative(ROOT, files[0]).replaceAll(path.sep, '/');
     const release = relative.match(/^releases\/([^/]+)\/info\.yaml$/);
     if (release && existsSync(files[0])) {
-      return ['--prefix', 'tools/sitegen', 'run', 'build', '--', '--incremental-release', release[1]];
+      return [...preview, '--incremental-release', release[1]];
     }
     if (relative === 'tools/sitegen/src/curation/discovery.yml') {
-      return ['--prefix', 'tools/sitegen', 'run', 'build', '--', '--incremental-curation', 'discovery'];
+      return [...preview, '--incremental-curation', 'discovery'];
     }
     if (relative === 'tools/sitegen/src/curation/flairs.yml') {
-      return ['--prefix', 'tools/sitegen', 'run', 'build', '--', '--incremental-curation', 'flairs'];
+      return [...preview, '--incremental-curation', 'flairs'];
     }
-    return ['run', 'build'];
+    return preview;
   }
 
   function runBuild() {


### PR DESCRIPTION
allows repo resident web configs to be served locally when running the local build