### PR TITLE
PoC 16mb affordances in the UI and schema at the uf2 level

### DIFF
--- a/documentation/info.yaml.md
+++ b/documentation/info.yaml.md
@@ -98,14 +98,20 @@ Add an optional `uf2:` list to curate this. **When `uf2:` is present it fully re
 |-------|----------|------|-------------|
 | `path` | either path or download | string | Path to the `.uf2` relative to the card folder (e.g. `UF2/goldfish.2.0.2mb.uf2`), matched case-insensitively. The build errors if the file is missing. |
 | `name` | no | string | Friendly label shown on the download tile instead of the filename. |
+| `flash` | no | `2mb` \| `16mb` | Blank-card flash size this firmware targets. **Omit for 2MB** (the default). Set `flash: 16mb` for a 16MB-only download. A card whose every UF2 entry is `16mb` is treated as 16MB-only on the site. When omitted, the build also infers `16mb` from filenames containing `16mb` or `16M` (and `2mb` from `2mb` / `2M`). An explicit `flash` value always wins. |
 | `download` | either path or download | object | `{ url, sha256, flashable? }` (`url` and `sha256` are required). `url` is an external mirror, direct firmware URL, or store/purchase page. It opens in a new tab, shows its host, and is tagged "External". Set `flashable: true` only for a direct UF2 URL whose host permits cross-origin browser requests (CORS); the site verifies `sha256` before erasing or writing the connected card. `sha256` is the firmware's hex digest (`shasum -a 256 file.uf2` on macOS). For repo-hosted firmware (via `path`) the build computes it automatically. |
 
 Do not add `sha256` beside a repository-hosted `path`; the build calculates that hash from the tracked file. Validation accepts it only to provide a warning that it is unnecessary.
+
+Do not add `flash: 2mb` on ordinary cards; 2MB is implicit. A future 16MB-only card is a card whose only UF2 entry has `flash: 16mb`.
 
 ```yaml
 uf2:
   - path: UF2/goldfish.2.0.2mb.uf2
     name: Goldfish 2.0 (2MB)
+  - path: UF2/goldfish.2.0.16mb.uf2
+    name: Goldfish 2.0 (16MB)
+    flash: 16mb
   - name: Buy a pre-flashed card
     download:
       url: https://example.com/store/goldfish

--- a/releases/42_backyard_rain/info.yaml
+++ b/releases/42_backyard_rain/info.yaml
@@ -35,6 +35,7 @@ uf2:
     path: backyard_rain_2M_2_0_0.uf2
   - name: Backyard Rain V2.0 - for 16MB cards 
     path: backyard_rain_16M_2_0_0.uf2
+    flash: 16mb
 
 demo-link: https://youtu.be/ABbWmZOtmig?si=bKNxzY5MFJ0kZ6UB&t=1772
 

--- a/releases/77_PunkConfusion/info.yaml
+++ b/releases/77_PunkConfusion/info.yaml
@@ -26,6 +26,7 @@ uf2:
     name: Punk Confusion Beta (2 MB)
   - path: uf2/punk_confusion_16mb.uf2
     name: Punk Confusion Beta (16 MB)
+    flash: 16mb
 
 tags:
   - synth

--- a/tools/sitegen/assets/js/catalogue-filters.js
+++ b/tools/sitegen/assets/js/catalogue-filters.js
@@ -4,6 +4,7 @@
   // search and creation-date sort.
   var creatorSel=document.getElementById('filter-creator');
   var tagInputs=Array.from(document.querySelectorAll('input[name="filter-tag"]'));
+  var flash16=document.getElementById('filter-flash-16mb');
   var tagSearch=document.getElementById('filter-tag-search');
   var tagGroup=document.querySelector('.tag-filter-group');
   var toggleAllTags=document.getElementById('toggle-all-tags');
@@ -37,17 +38,19 @@
     return m?parseInt(m[1], 10):null;
   }
 
-  function filterCollection(items, c, selectedTags, s){
+  function filterCollection(items, c, selectedTags, want16, s){
     var shown=0;
     var wantedNum=cardNumberQuery(s);
     visibleItems=[];
     items.forEach(function(el){
       var cr=(el.getAttribute('data-creator')||'').toLowerCase();
       var tags=(el.getAttribute('data-tags')||'').toLowerCase().split(/\s+/);
+      var flash=(el.getAttribute('data-flash')||'').toLowerCase().split(/\s+/);
       var st=(el.getAttribute('data-search')||'');
       var ok=true;
       if(c && cr!==c) ok=false;
       if(selectedTags.length && !selectedTags.some(function(tag){ return tags.indexOf(tag) !== -1; })) ok=false;
+      if(want16 && flash.indexOf('16mb')===-1) ok=false;
       if(wantedNum!==null){ if(parseInt(el.getAttribute('data-num'), 10)!==wantedNum) ok=false; }
       else if(s && st.indexOf(s)===-1) ok=false;
       el.style.display=ok?'':'none';
@@ -60,24 +63,27 @@
   function applyFilters(){
     var c=creatorSel&&creatorSel.value?creatorSel.value.toLowerCase():'';
     var selectedTags=tagInputs.filter(function(input){ return input.checked; }).map(function(input){ return input.value.toLowerCase(); });
+    var want16=!!(flash16&&flash16.checked);
     var raw=searchInput&&searchInput.value?searchInput.value:'';
     var s=raw.trim().toLowerCase();
 
     // A whitespace-only search - or Enter on an empty box - still counts as a
     // search: it lists every card.
-    var active = !!(c||selectedTags.length||raw||showAll);
+    var active = !!(c||selectedTags.length||want16||raw||showAll);
     // The unfiltered listing, however it was reached (toggle link, Enter or
     // whitespace in the search box).
-    listingAll = active && !c && !selectedTags.length && !s;
+    listingAll = active && !c && !selectedTags.length && !want16 && !s;
 
     if(allCardsLink) allCardsLink.textContent = listingAll ? 'Close card list' : allCardsLabel;
     if(searchClear) searchClear.style.display = active ? 'flex' : 'none';
     if(clearTags) clearTags.hidden = selectedTags.length === 0;
 
-    if(tagInputs.length && window.history && window.URL) {
+    if((tagInputs.length || flash16) && window.history && window.URL) {
       var url = new URL(window.location.href);
       url.searchParams.delete('tag');
       selectedTags.forEach(function(tag){ url.searchParams.append('tag', tag); });
+      if(want16) url.searchParams.set('flash', '16mb');
+      else url.searchParams.delete('flash');
       window.history.replaceState(null, '', url.pathname + url.search + url.hash);
     }
 
@@ -86,10 +92,10 @@
       if(discoveryEl) discoveryEl.hidden = active;
       resultsEl.hidden = !active;
       if(!active){ visibleItems=[]; return; }
-      filterCollection(resultsList?resultsList.querySelectorAll(itemSelector):[], c, selectedTags, s);
+      filterCollection(resultsList?resultsList.querySelectorAll(itemSelector):[], c, selectedTags, want16, s);
     } else if(archiveList){
       // Archive: filter rows in place
-      filterCollection(archiveList.querySelectorAll('.program-card-archive-row'), c, selectedTags, s);
+      filterCollection(archiveList.querySelectorAll('.program-card-archive-row'), c, selectedTags, want16, s);
     }
 
   }
@@ -132,7 +138,7 @@
   }
 
   function wire(sel, ev){if(!sel) return; sel.addEventListener(ev||'change',applyFilters);}
-  wire(creatorSel); tagInputs.forEach(function(input){
+  wire(creatorSel); wire(flash16); tagInputs.forEach(function(input){
     wire(input);
     input.addEventListener('change', applyTagOptionSearch);
   });
@@ -183,6 +189,7 @@
     showAll = false;
     if(searchInput) searchInput.value = '';
     if(creatorSel) creatorSel.value = '';
+    if(flash16) flash16.checked = false;
     tagInputs.forEach(function(input){ input.checked = false; });
     if(tagSearch) tagSearch.value = '';
     if(tagGroup) tagGroup.classList.remove('is-showing-all');
@@ -208,11 +215,12 @@
   if(tagInputs.length && window.URLSearchParams) {
     var requestedTags = new URLSearchParams(window.location.search).getAll('tag').map(function(tag){ return tag.toLowerCase(); });
     tagInputs.forEach(function(input){ input.checked = requestedTags.indexOf(input.value.toLowerCase()) !== -1; });
-    if(requestedTags.length) {
+    if(flash16 && new URLSearchParams(window.location.search).get('flash') === '16mb') flash16.checked = true;
+    if(requestedTags.length || (flash16 && flash16.checked)) {
       var advanced = document.querySelector('.advanced-options');
       if(advanced) advanced.open = true;
     }
   }
   applyTagOptionSearch();
-  if(creatorSel||tagInputs.length||searchInput) applyFilters();
+  if(creatorSel||tagInputs.length||flash16||searchInput) applyFilters();
 })();

--- a/tools/sitegen/assets/style.css
+++ b/tools/sitegen/assets/style.css
@@ -75,7 +75,7 @@ a { color: var(--link); }
 .advanced-options > summary::-webkit-details-marker { display: none; }
 .advanced-options > summary::before { content: "+ "; }
 .advanced-options[open] > summary::before { content: "− "; }
-.filter-row { align-items: start; display: grid; gap: 18px; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 3fr); margin-top: 14px; }
+.filter-row { align-items: start; display: grid; gap: 18px; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, auto) minmax(0, 3fr); margin-top: 14px; }
 .filter-group { display: grid; gap: 3px; }
 .tag-filter-group { border: 0; margin: 0; min-width: 0; padding: 0; }
 .tag-filter-group.is-showing-all { grid-column: 1/-1; }

--- a/tools/sitegen/src/build.js
+++ b/tools/sitegen/src/build.js
@@ -481,6 +481,7 @@ const PREVIEW_LIB_FILES = [
   'utils/video.js',
   'utils/audio.js',
   'utils/markdown.js',
+  'utils/flash.js',
   'utils/previewFirmware.js',
   'utils/previewWeb.js',
   'schema/schemaDefinition.js',

--- a/tools/sitegen/src/discover/downloads.js
+++ b/tools/sitegen/src/discover/downloads.js
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import { fsAsync as fs, toPosix, fileExists, sha256File } from '../utils/fs.js';
 import { getTrackedFileSet } from '../utils/git.js';
+import { assignDownloadFlash } from '../utils/flash.js';
 
 // Read a string property from an object by a case-insensitive key, trimmed.
 function readKeyCi(obj, name) {
@@ -8,6 +9,14 @@ function readKeyCi(obj, name) {
   const target = String(name).toLowerCase();
   for (const [k, v] of Object.entries(obj)) {
     if (k.toLowerCase() === target && typeof v === 'string') return v.trim();
+  }
+  return '';
+}
+
+function readFlash(obj) {
+  if (!obj || typeof obj !== 'object') return '';
+  for (const [k, v] of Object.entries(obj)) {
+    if (k.toLowerCase() === 'flash' && v != null && typeof v !== 'object') return String(v).trim();
   }
   return '';
 }
@@ -81,6 +90,7 @@ export async function discoverDownloads(absReleaseDir, repoRelBase, makeRawUrl) 
     const entry = { name: it.name, url: it.url, rel: it.rel, path: it.relRelease };
     const sha256 = await sha256File(it.abs);
     if (sha256) entry.sha256 = sha256;
+    assignDownloadFlash(entry);
     shaByReleasePath.set(it.relRelease, sha256);
     availableUf2Downloads.push(entry);
   }
@@ -101,6 +111,7 @@ export async function discoverDownloads(absReleaseDir, repoRelBase, makeRawUrl) 
     const entry = { name: it.name, url: it.url, rel: it.rel };
     const sha256 = shaByReleasePath.get(it.relRelease);
     if (sha256) entry.sha256 = sha256;
+    assignDownloadFlash(entry);
     uf2Downloads.push(entry);
   }
   const latestUf2 = uf2Downloads[0] || null;
@@ -142,7 +153,7 @@ async function resolveInsensitivePath(baseAbs, relPath) {
  * Build a curated UF2 download list from an author-specified `uf2:` field. When
  * present this fully replaces auto-discovery, letting authors trim noise and
  * annotate firmware. Each entry is an object:
- *   { path?, name?, download?: { url?, sha256? } }
+ *   { path?, name?, flash?, download?: { url?, sha256? } }
  * An entry needs EITHER a `path` (repo firmware, resolved case-insensitively;
  * missing file is an error) OR a `download.url` (an external/mirror/store link
  * that opens in a new tab and is tagged as external). For repo files the build
@@ -186,6 +197,7 @@ export async function curateUf2Downloads(uf2Field, absReleaseDir, repoRelBase, m
       };
       if (authorHash) item.sha256 = authorHash;
       if (download.flashable === true) item.flashable = true;
+      assignDownloadFlash(item, readFlash(entry));
       uf2Downloads.push(item);
       continue;
     }
@@ -208,6 +220,7 @@ export async function curateUf2Downloads(uf2Field, absReleaseDir, repoRelBase, m
     };
     const sha256 = await sha256File(path.join(absReleaseDir, realRel));
     if (sha256) item.sha256 = sha256;
+    assignDownloadFlash(item, readFlash(entry));
     uf2Downloads.push(item);
   }
   return { uf2Downloads, errors };

--- a/tools/sitegen/src/model/card.js
+++ b/tools/sitegen/src/model/card.js
@@ -10,6 +10,7 @@
 // the importer, so `Name`, `name`, and `NAME` all resolve to the same value.
 
 import { classifyDemoVideo } from '../utils/video.js';
+import { deriveMemoryFromDownloads } from '../utils/flash.js';
 
 // API jack id -> physical panel slot key (ported from the importer constants).
 const API_INPUT_KEYS = {
@@ -708,6 +709,8 @@ export function buildCanonicalCardModel({
   if (Array.isArray(docs) && docs.length) card.docs = sanitizeValue(docs);
   if (Array.isArray(downloads) && downloads.length) card.downloads = sanitizeValue(downloads);
   if (Array.isArray(uf2Downloads) && uf2Downloads.length) card.uf2_downloads = sanitizeValue(uf2Downloads);
+  const memory = deriveMemoryFromDownloads(card.uf2_downloads);
+  if (memory) card.memory = memory;
   if (Array.isArray(audioSamples) && audioSamples.length) {
     card.audio_samples = sanitizeValue(audioSamples);
     card.audio_sample_url = audioSamples[0].url;

--- a/tools/sitegen/src/render/cardPage.js
+++ b/tools/sitegen/src/render/cardPage.js
@@ -437,14 +437,16 @@ export function renderCardArticle({ card, panelImg, yamlUrl, uf2Url, extraDocs =
         if (d.external) {
           const host = d.host ? `<small class="program-card-action__host">${esc(d.host)}</small>` : '';
           const tag = '<small class="program-card-action__tag">External \u2197</small>';
+          const flashTag = d.flash === '16mb' ? '<small class="program-card-action__tag">16MB</small>' : '';
           const flashAttrs = d.flashable && d.sha256
             ? ` data-uf2-url="${esc(d.url)}" data-sha256="${esc(d.sha256)}"`
             : '';
-          return `<a class="program-card-action program-card-action--download program-card-action--external" href="${esc(d.url)}" target="_blank" rel="noopener noreferrer"${flashAttrs}><span class="program-card-action__label">Download</span><small>${esc(d.name)}</small>${host}${tag}</a>`;
+          return `<a class="program-card-action program-card-action--download program-card-action--external" href="${esc(d.url)}" target="_blank" rel="noopener noreferrer"${flashAttrs}><span class="program-card-action__label">Download</span><small>${esc(d.name)}</small>${host}${tag}${flashTag}</a>`;
         }
         // A repo file downloads directly, enables WebUSB, and exposes its SHA256.
         const hashAttr = d.sha256 ? ` data-sha256="${esc(d.sha256)}"` : '';
-        return `<a class="program-card-action program-card-action--download" href="${esc(d.url)}" download data-uf2-url="${esc(d.url)}"${hashAttr}><span class="program-card-action__label">Download</span><small class="program-card-action__firmware">${esc(d.name)}</small></a>`;
+        const flashTag = d.flash === '16mb' ? '<small class="program-card-action__tag">16MB</small>' : '';
+        return `<a class="program-card-action program-card-action--download" href="${esc(d.url)}" download data-uf2-url="${esc(d.url)}"${hashAttr}><span class="program-card-action__label">Download</span><small class="program-card-action__firmware">${esc(d.name)}</small>${flashTag}</a>`;
       }).join('')
     : (uf2Url || card.has_uf2_metadata ? (() => {
         const downloadHref = uf2Url || sourceUrl;

--- a/tools/sitegen/src/render/discovery.js
+++ b/tools/sitegen/src/render/discovery.js
@@ -6,6 +6,7 @@
 
 import { curation, resolveFlair } from '../curation/index.js';
 import { externalLinkArrow } from './icons.js';
+import { flashAttrFromDownloads, has16mbFirmware } from '../utils/flash.js';
 
 const CARD_ARTWORK = {
   '00_Simple_MIDI': '00-simple-midi.svg',
@@ -113,17 +114,19 @@ export function renderTile(card, opts = {}) {
     number, card.title, summary, metadata.creator, metadata.language,
     ...(Array.isArray(card.tags) ? card.tags : []),
     ...flair.map(f => f.label),
+    ...(has16mbFirmware(card.uf2_downloads) ? ['16mb'] : []),
   ].filter(Boolean).join(' ').toLowerCase();
 
   const flairFilter = flair.map(f => f.id);
   const authorTagFilter = (Array.isArray(card.tags) ? card.tags : []).map(tag => curation.slugify(tag)).filter(Boolean);
   const tagFilter = [...new Set([...flairFilter, ...authorTagFilter])].join(' ');
+  const flashFilter = flashAttrFromDownloads(card.uf2_downloads);
 
   return `<article class="program-card-tile${media ? ' program-card-tile--video' : ''}${artwork ? ' program-card-tile--artwork' : ''}"` +
     ` data-creator="${escapeAttr(metadata.creator || '')}" data-language="${escapeAttr(metadata.language || '')}"` +
     ` data-type="${escapeAttr(metadata.status || '')}" data-date="${escapeAttr(sortDate)}"` +
     ` data-name="${escapeAttr(String(card.title || card.id || '').toLowerCase())}" data-num="${escapeAttr(String(parseInt(number, 10) || 0))}"` +
-    ` data-tags="${escapeAttr(tagFilter)}" data-search="${escapeAttr(searchText)}">
+    ` data-tags="${escapeAttr(tagFilter)}" data-flash="${escapeAttr(flashFilter)}" data-search="${escapeAttr(searchText)}">
     <a class="program-card-tile__link" href="${card.id === '88_Blank' && showArtwork ? `${root}/random/` : `${root}/programs/${card.slug}/`}">
       ${media}
       <span class="program-card-tile__head"><span class="program-card-tile__title">${artwork || `<span class="program-card-tile__number">${esc(number)}</span>`}<span class="program-card-tile__name">${esc(truncate(card.title || card.id || 'Untitled card', 48))}</span>${showCreator && metadata.creator ? `<span class="program-card-tile__byline">by ${esc(metadata.creator)}</span>` : ''}</span></span>
@@ -188,13 +191,14 @@ function renderArchiveRow(card, root) {
   const flair = resolveFlair(card.id);
   const number = cardNumber(card);
   const summary = card.short_description || '';
-  const searchText = [number, card.title, summary, card.metadata?.creator, ...(Array.isArray(card.tags) ? card.tags : []), ...flair.map(f => f.label)]
+  const searchText = [number, card.title, summary, card.metadata?.creator, ...(Array.isArray(card.tags) ? card.tags : []), ...flair.map(f => f.label), ...(has16mbFirmware(card.uf2_downloads) ? ['16mb'] : [])]
     .filter(Boolean).join(' ').toLowerCase();
   const date = card.metadata?.created || '';
   const flairFilter = flair.map(f => f.id);
   const authorTagFilter = (Array.isArray(card.tags) ? card.tags : []).map(tag => curation.slugify(tag)).filter(Boolean);
   const tagFilter = [...new Set([...flairFilter, ...authorTagFilter])].join(' ');
-  return `<article class="program-card-archive-row" data-creator="${escapeAttr(card.metadata?.creator || '')}" data-date="${escapeAttr(date)}" data-name="${escapeAttr(String(card.title || '').toLowerCase())}" data-num="${escapeAttr(String(parseInt(number, 10) || 0))}" data-tags="${escapeAttr(tagFilter)}" data-search="${escapeAttr(searchText)}">
+  const flashFilter = flashAttrFromDownloads(card.uf2_downloads);
+  return `<article class="program-card-archive-row" data-creator="${escapeAttr(card.metadata?.creator || '')}" data-date="${escapeAttr(date)}" data-name="${escapeAttr(String(card.title || '').toLowerCase())}" data-num="${escapeAttr(String(parseInt(number, 10) || 0))}" data-tags="${escapeAttr(tagFilter)}" data-flash="${escapeAttr(flashFilter)}" data-search="${escapeAttr(searchText)}">
     <a class="program-card-archive-row__link" href="${root}/programs/${card.slug}/">
       <span class="program-card-archive-row__number">${esc(number)}</span>
       <span class="program-card-archive-row__main"><span class="program-card-archive-row__heading"><span class="program-card-archive-row__title">${esc(card.title)}</span>${card.metadata?.creator ? `<span class="program-card-archive-row__byline">by ${esc(card.metadata.creator)}</span>` : ''}</span>${summary ? `<span class="program-card-archive-row__summary">${esc(truncate(summary, 120))}</span>` : ''}</span>

--- a/tools/sitegen/src/render/filterBar.js
+++ b/tools/sitegen/src/render/filterBar.js
@@ -30,6 +30,10 @@ export function renderFilterBar({ creatorOptions, sortOptions, tagOptions, linkH
             <label for="sort-mode">Sort</label>
             <select id="sort-mode">${sortOptions}</select>
           </div>
+          <div class="filter-group">
+            <label for="filter-flash-16mb">Flash</label>
+            <label class="tag-filter-option program-card-tag" for="filter-flash-16mb"><input id="filter-flash-16mb" type="checkbox" name="filter-flash" value="16mb"> <span>16MB firmware</span></label>
+          </div>
           <fieldset class="filter-group tag-filter-group">
             <legend class="tag-filter-heading"><span>Tags</span><span class="tag-filter-heading__actions"><button id="clear-tags" type="button" hidden>Clear</button></span></legend>
             <input id="filter-tag-search" class="tag-filter-search" type="search" placeholder="Search all tags…" aria-label="Search all tags" autocomplete="off">

--- a/tools/sitegen/src/schema/infoYamlJsonSchema.js
+++ b/tools/sitegen/src/schema/infoYamlJsonSchema.js
@@ -79,6 +79,7 @@ const uf2Entry = {
   properties: {
     path: { type: 'string', minLength: 1, pattern: '\\.[Uu][Ff]2$' },
     name: nonBlankText,
+    flash: { enum: ['2mb', '16mb'] },
     sha256: { type: 'string', pattern: '^[A-Fa-f0-9]{64}$' },
     download: uf2Download,
   },

--- a/tools/sitegen/src/schema/schemaDefinition.js
+++ b/tools/sitegen/src/schema/schemaDefinition.js
@@ -26,6 +26,6 @@ export const infoYamlSchema = {
     { path: 'panel', type: 'object', required: false, description: 'Panel jack metadata. Unconditioned entries form the base; when.z targets generated physical-position panels and when.panel targets an id from panels/manifest.yaml.' },
     { path: 'controls', type: 'object', required: false, description: 'Control metadata. Switch keys are up/middle/down plus tap; conditions may use when.z for generated views or when.panel for custom views.' },
     { path: 'host', type: 'object', required: false, description: 'Host connectivity metadata.' },
-    { path: 'uf2', type: 'array', required: false, description: 'Curated firmware download list; when present it overrides auto-discovery. Each item needs a path OR a download.url: { path?, name?, download?: { url, sha256 } }.' },
+    { path: 'uf2', type: 'array', required: false, description: 'Curated firmware download list; when present it overrides auto-discovery. Each item needs a path OR a download.url: { path?, name?, flash?, download?: { url, sha256 } }. flash is 2mb (omit; the default) or 16mb.' },
   ],
 };

--- a/tools/sitegen/src/utils/flash.js
+++ b/tools/sitegen/src/utils/flash.js
@@ -1,0 +1,68 @@
+export const FLASH_2MB = '2mb';
+export const FLASH_16MB = '16mb';
+
+/** Normalize an authored flash size, or null when absent/unknown. */
+export function normalizeFlash(value) {
+  if (value == null || value === '') return null;
+  const text = String(value).trim().toLowerCase();
+  if (text === '2mb' || text === '2m') return FLASH_2MB;
+  if (text === '16mb' || text === '16m') return FLASH_16MB;
+  return null;
+}
+
+/**
+ * Infer 2mb/16mb from a firmware path or filename. 16MB tokens win so
+ * names like goldfish.2.0.16mb.uf2 are not parsed as 2MB.
+ */
+export function inferFlashFromFilename(name) {
+  const text = String(name || '');
+  if (/(?:^|[^0-9])16m(?:b)?(?![a-z0-9])/i.test(text)) return FLASH_16MB;
+  if (/(?:^|[^0-9])2m(?:b)?(?![a-z0-9])/i.test(text)) return FLASH_2MB;
+  return null;
+}
+
+/** Resolve flash for a download: explicit authored value, else filename, else 2MB. */
+export function resolveDownloadFlash(item = {}, authoredFlash) {
+  const explicit = normalizeFlash(authoredFlash);
+  if (explicit) return explicit;
+  const source = [item.rel, item.path, item.name, item.url].filter(Boolean).join('/');
+  return inferFlashFromFilename(source) || FLASH_2MB;
+}
+
+/**
+ * Attach flash onto a download item. Implicit 2MB is omitted so ordinary
+ * firmware stays unmarked; explicit 2mb is kept to honour an override.
+ */
+export function assignDownloadFlash(item, authoredFlash) {
+  if (!item || typeof item !== 'object') return item;
+  const authored = normalizeFlash(authoredFlash);
+  const flash = resolveDownloadFlash(item, authoredFlash);
+  if (flash === FLASH_16MB) item.flash = FLASH_16MB;
+  else if (authored === FLASH_2MB) item.flash = FLASH_2MB;
+  else delete item.flash;
+  return item;
+}
+
+/** Space-separated sizes for data-flash: "2mb", "16mb", or "2mb 16mb". */
+export function flashAttrFromDownloads(downloads) {
+  const sizes = new Set();
+  for (const item of Array.isArray(downloads) ? downloads : []) {
+    sizes.add(item && item.flash === FLASH_16MB ? FLASH_16MB : FLASH_2MB);
+  }
+  if (!sizes.size) sizes.add(FLASH_2MB);
+  return [FLASH_2MB, FLASH_16MB].filter(size => sizes.has(size)).join(' ');
+}
+
+export function has16mbFirmware(downloads) {
+  return (Array.isArray(downloads) ? downloads : []).some(item => item && item.flash === FLASH_16MB);
+}
+
+/** Card-level memory badge only when every UF2 is 16MB. */
+export function deriveMemoryFromDownloads(downloads) {
+  const list = Array.isArray(downloads) ? downloads.filter(Boolean) : [];
+  if (!list.length) return undefined;
+  if (list.every(item => item.flash === FLASH_16MB)) {
+    return { size: FLASH_16MB, requirement: 'only' };
+  }
+  return undefined;
+}

--- a/tools/sitegen/src/utils/previewFirmware.js
+++ b/tools/sitegen/src/utils/previewFirmware.js
@@ -1,4 +1,5 @@
 import { normalizeYamlKey } from './strings.js';
+import { assignDownloadFlash } from './flash.js';
 
 function readUf2Field(raw) {
   for (const [key, value] of Object.entries(raw || {})) {
@@ -28,7 +29,7 @@ function nameFromUrl(value) {
 export function resolvePreviewUf2Downloads(raw, availableDownloads = []) {
   const field = readUf2Field(raw);
   if (field == null || (Array.isArray(field) && field.length === 0)) {
-    return availableDownloads.map(item => ({ ...item }));
+    return availableDownloads.map(item => assignDownloadFlash({ ...item }));
   }
 
   const available = new Map();
@@ -51,13 +52,18 @@ export function resolvePreviewUf2Downloads(raw, availableDownloads = []) {
       const sha256 = String(entry.download?.sha256 || '').trim().toLowerCase();
       if (sha256) item.sha256 = sha256;
       if (entry.download?.flashable === true) item.flashable = true;
+      assignDownloadFlash(item, entry.flash);
       resolved.push(item);
       continue;
     }
 
     const path = String(entry.path || '').trim().replaceAll('\\', '/');
     const match = available.get(path.toLowerCase());
-    if (match) resolved.push({ ...match, name: String(entry.name || '').trim() || match.name });
+    if (match) {
+      const item = { ...match, name: String(entry.name || '').trim() || match.name };
+      assignDownloadFlash(item, entry.flash);
+      resolved.push(item);
+    }
   }
   return resolved;
 }

--- a/tools/sitegen/src/validate/rules/index.js
+++ b/tools/sitegen/src/validate/rules/index.js
@@ -357,6 +357,14 @@ export const uf2Entries = {
         out.push({ severity: 'warning', path: `${at}.name`, key: 'uf2',
           message: `${at}.name should be a string.` });
       }
+      const flashEntry = Object.entries(entry).find(([k]) => k.toLowerCase() === 'flash');
+      if (flashEntry && !isBlank(flashEntry[1])) {
+        const flash = String(flashEntry[1]).trim().toLowerCase();
+        if (flash !== '2mb' && flash !== '16mb') {
+          out.push({ severity: 'warning', path: `${at}.flash`, key: 'uf2',
+            message: `${at}.flash should be "2mb" or "16mb" (omit for 2MB).` });
+        }
+      }
       if (hasPath && !hasUrl && shaEntry && !isBlank(shaEntry[1])) {
         out.push({ severity: 'warning', path: `${at}.sha256`, key: 'uf2',
           message: `${at}.sha256 is not required for repository-hosted firmware; the build computes it automatically.` });

--- a/tools/sitegen/test/card.test.js
+++ b/tools/sitegen/test/card.test.js
@@ -97,6 +97,18 @@ test('authored UF2 entries are retained as a download-availability signal', () =
   assert.equal(build({}).has_uf2_metadata, undefined);
 });
 
+test('card memory is derived only when every UF2 download is 16MB', () => {
+  assert.equal(build({}, { uf2Downloads: [{ name: 'card.uf2' }] }).memory, undefined);
+  assert.deepEqual(
+    build({}, { uf2Downloads: [{ name: 'card.uf2', flash: '16mb' }] }).memory,
+    { size: '16mb', requirement: 'only' },
+  );
+  assert.equal(build({}, { uf2Downloads: [
+    { name: 'card_2mb.uf2' },
+    { name: 'card_16mb.uf2', flash: '16mb' },
+  ] }).memory, undefined);
+});
+
 test('demo-link YouTube URL produces a videos entry', () => {
   const card = build({ 'demo-link': 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' });
   assert.equal(card.videos.length, 1);

--- a/tools/sitegen/test/discovery.test.js
+++ b/tools/sitegen/test/discovery.test.js
@@ -128,6 +128,24 @@ test('curated firmware resolves case-insensitive paths, hashes files, and handle
   });
 });
 
+test('curated firmware attaches explicit and inferred flash sizes', async t => {
+  const release = await fixture(t);
+  await write(path.join(release, 'uf2', 'punk_confusion_2mb.uf2'), 'two');
+  await write(path.join(release, 'uf2', 'punk_confusion_16mb.uf2'), 'sixteen');
+  await write(path.join(release, 'card.uf2'), 'plain');
+  const { uf2Downloads, errors } = await curateUf2Downloads([
+    { path: 'uf2/punk_confusion_2mb.uf2', name: '2 MB' },
+    { path: 'uf2/punk_confusion_16mb.uf2', name: '16 MB', flash: '16mb' },
+    { path: 'card.uf2', name: 'Unmarked' },
+    { path: 'uf2/punk_confusion_16mb.uf2', name: 'Override', flash: '2mb' },
+  ], release, 'releases/77_fixture', relative => `https://raw.test/${relative}`);
+  assert.deepEqual(errors, []);
+  assert.equal(uf2Downloads[0].flash, undefined);
+  assert.equal(uf2Downloads[1].flash, '16mb');
+  assert.equal(uf2Downloads[2].flash, undefined);
+  assert.equal(uf2Downloads[3].flash, '2mb');
+});
+
 test('external firmware rejects active protocols and unhashed browser flashing', async t => {
   const release = await fixture(t);
   const { uf2Downloads, errors } = await curateUf2Downloads([

--- a/tools/sitegen/test/preview-firmware.test.js
+++ b/tools/sitegen/test/preview-firmware.test.js
@@ -33,8 +33,19 @@ test('author preview external UF2 metadata matches card-detail download data', (
   }]);
 });
 
-test('removing or invalidating curated UF2 entries removes stale preview downloads', () => {
-  assert.deepEqual(resolvePreviewUf2Downloads({ uf2: [{ path: 'missing.uf2' }] }, available), []);
+test('author preview infers and honours curated flash sizes', () => {
+  const available = [
+    { path: 'UF2/goldfish.2.0.2mb.uf2', name: 'goldfish.2.0.2mb.uf2', url: 'https://raw.test/2.uf2' },
+    { path: 'UF2/goldfish.2.0.16mb.uf2', name: 'goldfish.2.0.16mb.uf2', url: 'https://raw.test/16.uf2' },
+  ];
+  const inferred = resolvePreviewUf2Downloads({}, available);
+  assert.equal(inferred[0].flash, undefined);
+  assert.equal(inferred[1].flash, '16mb');
+  const curated = resolvePreviewUf2Downloads({ uf2: [
+    { path: 'UF2/goldfish.2.0.16mb.uf2', name: 'Goldfish 16MB', flash: '16mb' },
+  ] }, available);
+  assert.equal(curated[0].flash, '16mb');
+  assert.equal(curated[0].name, 'Goldfish 16MB');
 });
 
 test('author preview CSS keeps download and web-editor action tiles visible', () => {

--- a/tools/sitegen/test/render.test.js
+++ b/tools/sitegen/test/render.test.js
@@ -2,6 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { renderCardArticle, renderPanelArtwork, renderReadmeAndDocs } from '../src/render/cardPage.js';
 import { renderArchive, renderShelf, renderTile } from '../src/render/discovery.js';
+import { renderFilterBar } from '../src/render/filterBar.js';
 import { renderLayout } from '../src/render/layout.js';
 import { renderAuthorPage } from '../src/render/authorPage.js';
 
@@ -202,6 +203,48 @@ test('download action requires firmware, an external link, or authored UF2 metad
   });
   assert.match(declared, /program-card-action--download/);
   assert.match(declared, /href="https:\/\/example\.test\/source"/);
+});
+
+test('16MB firmware is tagged on download tiles and omitted for implicit 2MB', () => {
+  const html = renderCardArticle({ card: card({ uf2_downloads: [
+    { name: 'Local 2MB', url: 'two.uf2', sha256: 'aa' },
+    { name: 'Local 16MB', url: 'sixteen.uf2', sha256: 'bb', flash: '16mb' },
+  ] }), panelImg: 'panel.svg', yamlUrl: 'source.yaml' });
+  assert.match(html, /Local 16MB<\/small><small class="program-card-action__tag">16MB<\/small>/);
+  assert.doesNotMatch(html, /Local 2MB<\/small><small class="program-card-action__tag">16MB<\/small>/);
+  assert.doesNotMatch(html, /Card memory/);
+});
+
+test('cards whose every UF2 is 16MB show a 16MB-only memory line', () => {
+  const html = renderCardArticle({
+    card: card({
+      memory: { size: '16mb', requirement: 'only' },
+      uf2_downloads: [{ name: 'Only', url: 'only.uf2', flash: '16mb' }],
+    }),
+    panelImg: 'panel.svg', yamlUrl: 'source.yaml',
+  });
+  assert.match(html, /program-card-hero__meta/);
+  assert.match(html, /16MB card only/);
+  assert.match(html, /<dt>Card memory<\/dt><dd>16MB only<\/dd>/);
+});
+
+test('catalogue tiles expose flash size for search and the 16MB filter', () => {
+  const mixed = card({ uf2_downloads: [
+    { name: 'two.uf2' },
+    { name: 'sixteen.uf2', flash: '16mb' },
+  ] });
+  const tile = renderTile(mixed);
+  assert.match(tile, /data-flash="2mb 16mb"/);
+  assert.match(tile, /data-search="[^"]*16mb/);
+  const only = renderTile(card({ uf2_downloads: [{ name: 'sixteen.uf2', flash: '16mb' }] }));
+  assert.match(only, /data-flash="16mb"/);
+  assert.match(renderArchive([mixed]), /data-flash="2mb 16mb"/);
+  const bar = renderFilterBar({
+    creatorOptions: '', sortOptions: '', tagOptions: '',
+    linkHref: 'archive/', linkText: 'All cards',
+  });
+  assert.match(bar, /id="filter-flash-16mb"/);
+  assert.match(bar, /16MB firmware/);
 });
 
 test('card details render configured creation and update dates', () => {

--- a/tools/sitegen/test/utils.test.js
+++ b/tools/sitegen/test/utils.test.js
@@ -8,6 +8,10 @@ import { extractIframeSrc, classifyAudioUrl, resolveAudioSamples } from '../src/
 import { parseInstagram, instagramEmbedHtml } from '../src/utils/instagram.js';
 import { classifyDemoVideo, videoEmbedHtml } from '../src/utils/video.js';
 import { parseYoutubeId, parseYoutubeStartSeconds, youtubeEmbedHtml } from '../src/utils/youtube.js';
+import {
+  inferFlashFromFilename, normalizeFlash, resolveDownloadFlash, assignDownloadFlash,
+  flashAttrFromDownloads, deriveMemoryFromDownloads,
+} from '../src/utils/flash.js';
 
 test('normalizeYamlKey strips spaces and hyphens, lowercases', () => {
   assert.equal(normalizeYamlKey('demo-link'), 'demolink');
@@ -166,4 +170,31 @@ test('youtubeEmbedHtml includes start= when the source URL has a time offset', (
     /start=1772/,
   );
   assert.doesNotMatch(youtubeEmbedHtml('https://youtu.be/ABbWmZOtmig'), /start=/);
+});
+
+test('flash size inference reads 2mb/16mb tokens and ignores unmarked names', () => {
+  assert.equal(inferFlashFromFilename('goldfish.2.0.16mb.uf2'), '16mb');
+  assert.equal(inferFlashFromFilename('backyard_rain_16M_2_0_0.uf2'), '16mb');
+  assert.equal(inferFlashFromFilename('433_sense_of_space_16mb_mayakovsky_cc0.uf2'), '16mb');
+  assert.equal(inferFlashFromFilename('punk_confusion_2mb.uf2'), '2mb');
+  assert.equal(inferFlashFromFilename('backyard_rain_2M_2_0_0.uf2'), '2mb');
+  assert.equal(inferFlashFromFilename('goldfish.1.1.uf2'), null);
+  assert.equal(inferFlashFromFilename('goldfish.2.0.2mb.uf2'), '2mb');
+});
+
+test('authored flash overrides filename inference; omit defaults to 2MB', () => {
+  assert.equal(normalizeFlash('16MB'), '16mb');
+  assert.equal(normalizeFlash('2m'), '2mb');
+  assert.equal(normalizeFlash('32mb'), null);
+  assert.equal(resolveDownloadFlash({ name: 'card_16mb.uf2' }), '16mb');
+  assert.equal(resolveDownloadFlash({ name: 'card_16mb.uf2' }, '2mb'), '2mb');
+  assert.equal(resolveDownloadFlash({ name: 'card.uf2' }), '2mb');
+  assert.equal(assignDownloadFlash({ name: 'card.uf2' }).flash, undefined);
+  assert.equal(assignDownloadFlash({ name: 'card.uf2' }, '16mb').flash, '16mb');
+  assert.equal(assignDownloadFlash({ name: 'card_16mb.uf2' }, '2mb').flash, '2mb');
+  assert.equal(flashAttrFromDownloads([{ name: 'a.uf2' }, { name: 'b.uf2', flash: '16mb' }]), '2mb 16mb');
+  assert.equal(flashAttrFromDownloads([{ flash: '16mb' }]), '16mb');
+  assert.equal(flashAttrFromDownloads([]), '2mb');
+  assert.deepEqual(deriveMemoryFromDownloads([{ flash: '16mb' }]), { size: '16mb', requirement: 'only' });
+  assert.equal(deriveMemoryFromDownloads([{ name: 'a.uf2' }, { flash: '16mb' }]), undefined);
 });

--- a/tools/sitegen/test/validate.test.js
+++ b/tools/sitegen/test/validate.test.js
@@ -459,6 +459,54 @@ uf2:
     d.ruleId === 'ajv-schema' && d.severity === 'error' && d.path === 'uf2.0.download.sha256'));
 });
 
+test('uf2 flash defaults to 2MB and accepts 16mb', () => {
+  const omitted = validate(`
+Name: Firmware
+short-description: Short
+summary: Long
+Language: C++
+Creator: Someone
+Version: "1.0"
+Status: Released
+uf2:
+  - path: firmware/card.uf2
+`);
+  assert.ok(!omitted.diagnostics.some(d => String(d.path || '').includes('flash')));
+
+  const explicit = validate(`
+Name: Firmware
+short-description: Short
+summary: Long
+Language: C++
+Creator: Someone
+Version: "1.0"
+Status: Released
+uf2:
+  - path: firmware/card.uf2
+    flash: 16mb
+`);
+  assert.ok(!explicit.diagnostics.some(d => String(d.path || '').includes('flash')));
+});
+
+test('invalid uf2 flash values are rejected', () => {
+  const result = validate(`
+Name: Firmware
+short-description: Short
+summary: Long
+Language: C++
+Creator: Someone
+Version: "1.0"
+Status: Released
+uf2:
+  - path: firmware/card.uf2
+    flash: 32mb
+`);
+  assert.ok(result.diagnostics.some(d =>
+    d.ruleId === 'uf2-entries' && d.severity === 'warning' && d.path === 'uf2[0].flash'));
+  assert.ok(result.diagnostics.some(d =>
+    d.ruleId === 'ajv-schema' && d.path === 'uf2.0.flash'));
+});
+
 test('when cannot combine z and panel', () => {
   const result = validate(`
 Name: X


### PR DESCRIPTION
add `flash` field to `uf2`, all cards are implicitly 2mb, a card with a sole uf2 that's 16mb is 16mb _only_

adds a 16mb filter: 
<img width="899" height="738" alt="image" src="https://github.com/user-attachments/assets/e8cfbf0a-4a22-478b-9bfa-cde671f81a65" />

<img width="877" height="479" alt="image" src="https://github.com/user-attachments/assets/2b5c9ebf-fb10-4baf-aa89-e6089ce2032b" />
