### PR TITLE
Clean up Dub Warning release metadata

### DIFF
--- a/releases/999_Dub_Warning/LICENSE
+++ b/releases/999_Dub_Warning/LICENSE
@@ -1,0 +1,24 @@
+MIT License
+
+Copyright (c) 2026 Adrian Vos
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+Third-party notice: ComputerCard.h is the Music Thing Modular card library by
+Chris Johnson and keeps its own MIT licence.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/releases/999_Dub_Warning/README.md
+++ b/releases/999_Dub_Warning/README.md
@@ -60,7 +60,7 @@ hit the switch or a pulse input when you want the siren to shout.
 
 ## Test
 
-Use `test_uf2/DubWarning_PT2399_TEST.uf2` for hardware testing. The full input
+Use `UF2/DubWarning.uf2` for hardware testing. The full input
 and output test checklist is in `TEST_PROCESS.md`.
 
 ## Development notes
@@ -82,3 +82,16 @@ make
 
 The dev container will configure CMake, build the firmware, and stage the UF2 in
 `UF2/`.
+
+## Credits
+
+- Dub Warning for the Workshop Computer by Adrian Vos, 2026.
+- ComputerCard is the Music Thing Modular card library by Chris Johnson, MIT,
+  included here as `ComputerCard.h`.
+- Music Thing Modular Workshop System Computer by Tom Whitwell / Music Thing
+  Modular.
+
+## License
+
+Dub Warning is released under the [MIT License](LICENSE). `ComputerCard.h`
+keeps its own MIT license and attribution to Chris Johnson.

--- a/releases/999_Dub_Warning/TEST_PROCESS.md
+++ b/releases/999_Dub_Warning/TEST_PROCESS.md
@@ -2,7 +2,7 @@
 
 Current beta result: passed single-device hardware testing.
 
-Use `test_uf2/DubWarning_PT2399_TEST.uf2`.
+Use `UF2/DubWarning.uf2`.
 
 ## Setup
 

--- a/releases/999_Dub_Warning/info.yaml
+++ b/releases/999_Dub_Warning/info.yaml
@@ -88,10 +88,7 @@ controls:
       description: Triggered siren that fades after Pulse In 1
     down:
       name: Wheel Up / Reset
-      description: Tap to fire the Wheel Up one-shot and reset phase
-    tap:
-      name: Wheel Up
-      description: Briefly tap Down to fire the Wheel Up gesture from the panel
+      description: Move Down to fire the Wheel Up one-shot and reset phase
   knobs:
     - main:
         name: Pitch


### PR DESCRIPTION
Follow-up to the merged Dub Warning card PR. This keeps the changes limited to releases/999_Dub_Warning: adds the MIT license with ComputerCard attribution, points docs at the release UF2, and removes the duplicate Down/tap behaviour from info.yaml.