### PR TITLE
Info and readme polish

### DIFF
--- a/releases/101_Gnarly_C1ZZL3/C1ZZL3_Gnarly_quick_reference.txt
+++ b/releases/101_Gnarly_C1ZZL3/C1ZZL3_Gnarly_quick_reference.txt
@@ -7,7 +7,7 @@ Checksum: 5782a8a0f77ef2d8ebd0433f6da3b7d5b1398627d82b163600f586a5cbf6bf4e
 
 Important identity
 ------------------
-- Gnarly is the no-Turing C1ZZL3 branch.
+- Gnarly is the no-Turing C1ZZL3 version.
 - Core remains the simpler production C1ZZL3 card 84.
 - Rad can be added to card 84 later as the advanced-with-Turing version.
 

--- a/releases/101_Gnarly_C1ZZL3/CARD_README.md
+++ b/releases/101_Gnarly_C1ZZL3/CARD_README.md
@@ -1,8 +1,8 @@
 # C1ZZL3 Gnarly Card Guide
 
 C1ZZL3 Gnarly is a dual-oscillator phase-distortion synth for the Music Thing
-Modular Workshop Computer. It is the no-Turing, performance-focused branch of
-C1ZZL3, with two oscillator lanes, recipe wave banks, named sound presets, and
+Modular Workshop Computer. It is a no-Turing, performance-focused C1ZZL3
+version, with two oscillator lanes, recipe wave banks, named sound presets, and
 CZ patch import support.
 
 ## What It Does

--- a/releases/101_Gnarly_C1ZZL3/README.md
+++ b/releases/101_Gnarly_C1ZZL3/README.md
@@ -3,7 +3,7 @@
 C1ZZL3 Gnarly is a dual-oscillator phase-distortion synth card for the Music
 Thing Modular Workshop Computer.
 
-Gnarly is the most complex C1ZZL3 branch. It keeps the Web MIDI sound-preset
+Gnarly is the most complexVersion of C1ZZL3. It keeps the Web MIDI sound-preset
 workflow from the advanced C1ZZL3 experiments, but removes the Turing machine
 panel mode so the hardware controls can focus on oscillator editing, recipe wave
 banks, ring modulation, and noise/grit.
@@ -23,8 +23,7 @@ release: 101 / Gnarly protocol v11 stable
 draft: false
 ```
 
-Core C1ZZL3 remains card 84. Rad can be added to card 84 in due course as an
-additional version. Gnarly is prepared here as a separate card identity because
+Core C1ZZL3 remains card 84. Gnarly is prepared here as a separate card identity because
 its hardware behaviour is substantially different.
 
 ## Stable Build

--- a/releases/101_Gnarly_C1ZZL3/info.yaml
+++ b/releases/101_Gnarly_C1ZZL3/info.yaml
@@ -42,7 +42,7 @@ panel:
     - id: PulseIn1
       name: Unused
       type: pulse
-      description: Unused in this no-Turing Gnarly branch.
+      description: Unused in this no-Turing Gnarly firmware.
     - id: PulseIn2
       name: Envelope Trig
       type: pulse
@@ -59,19 +59,19 @@ panel:
     - id: CVOut1
       name: Off
       type: cv
-      description: Held low in this no-Turing Gnarly branch.
+      description: Held low in this no-Turing Gnarly firmware.
     - id: CVOut2
       name: Off
       type: cv
-      description: Held low in this no-Turing Gnarly branch.
+      description: Held low in this no-Turing Gnarly firmware.
     - id: PulseOut1
       name: Off
       type: pulse
-      description: Held low in this no-Turing Gnarly branch.
+      description: Held low in this no-Turing Gnarly firmware.
     - id: PulseOut2
       name: Off
       type: pulse
-      description: Held low in this no-Turing Gnarly branch.
+      description: Held low in this no-Turing Gnarly firmware.
 
 controls:
   switch:
@@ -151,7 +151,7 @@ host:
     Web MIDI: use the GnarlyC1zzl3 Lab for Amp1/Amp2, PD1/PD2, Pitch1/Pitch2,
     recipe bank, named sound presets, and CZ Import Lab handoff.
 
-    Demo video note: for the main Turing-enabled Core 1.4 / Rad v9 branch, also
+    Demo video note: for the main Turing-enabled Core 1.4 / Rad v9 version, also
     refer to the Cosmik C1ZZL3 demo video.
 
 

--- a/releases/101_Gnarly_C1ZZL3/info.yaml
+++ b/releases/101_Gnarly_C1ZZL3/info.yaml
@@ -1,11 +1,11 @@
 draft: false
 Name: C1ZZL3 Gnarly
 short-description: >-
-  No-Turing dual-oscillator C1ZZL3 branch with recipe wave banks, named Web MIDI
+  Dual-oscillator phase distortion synth voice with recipe wave banks, named Web MIDI
   sound presets, separate oscillator envelopes, CZ patch import support, and an
   eight-knob MIDI CC performance block.
 summary: >-
-  No-Turing dual-oscillator C1ZZL3 branch with recipe wave banks, named Web MIDI
+  Dual-oscillator phase distortion synth voice with recipe wave banks, named Web MIDI
   sound presets, separate oscillator amplitude/phase-distortion/pitch envelopes,
   CZ patch import support, and an eight-knob MIDI CC performance block.
 Language: C++ (Pico SDK)
@@ -144,11 +144,11 @@ controls:
 
 host:
   notes: >-
-    This branch intentionally removes Turing CV, pulse, and generated MIDI
+    This version of the C1ZZL3 firmware removes Turing CV, pulse, and generated MIDI
     output so the physical panel can focus on dual-oscillator tone controls.
 
 
-    Web MIDI: use the Gnarly Lab for Amp1/Amp2, PD1/PD2, Pitch1/Pitch2,
+    Web MIDI: use the GnarlyC1zzl3 Lab for Amp1/Amp2, PD1/PD2, Pitch1/Pitch2,
     recipe bank, named sound presets, and CZ Import Lab handoff.
 
     Demo video note: for the main Turing-enabled Core 1.4 / Rad v9 branch, also


### PR DESCRIPTION
Adjusted the metadata and readme to read "version" or "firmware' rather than "branch" because the residual changes from when I was working on it annoyed me (and made things confusing)