### PR TITLE
Render all-input or all-output unused squares on site + eval for updated cards with draft: true

### DIFF
--- a/releases/92_usb_midi_host_synth/info.yaml
+++ b/releases/92_usb_midi_host_synth/info.yaml
@@ -1,4 +1,4 @@
-draft: true
+draft: false
 Name: USB MIDI Host
 short-description: USB MIDI host/device to CV, gate, and audio, with a browser editor for config and testing
 summary: |
@@ -33,25 +33,6 @@ tags:
   - utility
 
 panel:
-  inputs:
-    - id: AudioIn1
-      name: Not used
-      description: No audio input processing in current firmware
-    - id: AudioIn2
-      name: Not used
-      description: No audio input processing in current firmware
-    - id: CVIn1
-      name: Not used
-      description: CV inputs are not mapped in current firmware
-    - id: CVIn2
-      name: Not used
-      description: CV inputs are not mapped in current firmware
-    - id: PulseIn1
-      name: Not used
-      description: Pulse inputs are not mapped in current firmware
-    - id: PulseIn2
-      name: Not used
-      description: Pulse inputs are not mapped in current firmware
   outputs:
     - id: AudioOut1
       name: Audio mix L

--- a/tools/sitegen/package-lock.json
+++ b/tools/sitegen/package-lock.json
@@ -1091,79 +1091,79 @@
       }
     },
     "node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-3.1.1.tgz",
+      "integrity": "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==",
       "license": "MIT",
       "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0",
+        "entities": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       },
       "funding": {
+        "type": "github",
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
       }
     },
-    "node_modules/dom-serializer/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-3.0.0.tgz",
+      "integrity": "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/fb55"
         }
       ],
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      }
     },
     "node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-6.0.1.tgz",
+      "integrity": "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "domelementtype": "^2.3.0"
+        "domelementtype": "^3.0.0"
       },
       "engines": {
-        "node": ">= 4"
+        "node": ">=20.19.0"
       },
       "funding": {
+        "type": "github",
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
     "node_modules/domutils": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
-      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-4.0.2.tgz",
+      "integrity": "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3"
+        "dom-serializer": "^3.0.0",
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       },
       "funding": {
+        "type": "github",
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/entities": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
-      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=0.12"
+        "node": ">=20.19.0"
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
@@ -1704,9 +1704,9 @@
       }
     },
     "node_modules/htmlparser2": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
-      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-12.0.0.tgz",
+      "integrity": "sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -1716,10 +1716,13 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.2.2",
-        "entities": "^7.0.1"
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0",
+        "domutils": "^4.0.2",
+        "entities": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/is-plain-object": {
@@ -2047,18 +2050,21 @@
       }
     },
     "node_modules/sanitize-html": {
-      "version": "2.17.5",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.5.tgz",
-      "integrity": "sha512-ZmU1joGRrvoyctKIiuwUxqR6moLoU2Wk+2bMccN6f7UwhAmwYDvWziqPxRDDN2Qip62NqnIrVrT9akbL6Wretg==",
+      "version": "2.17.7",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.7.tgz",
+      "integrity": "sha512-PGtEkc9cbnedU3s9TmzDbpsZ8w086g/0Q8k8/oIO1NLNU3i5k9yn835CrjJSajp1KMmkisbO1qPXxNKO3welAg==",
       "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",
-        "htmlparser2": "^10.1.0",
+        "htmlparser2": "^12.0.0",
         "is-plain-object": "^5.0.0",
         "launder": "^1.7.1",
         "parse-srcset": "^1.0.2",
         "postcss": "^8.3.11"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/source-map-js": {

--- a/tools/sitegen/src/render/cardPage.js
+++ b/tools/sitegen/src/render/cardPage.js
@@ -200,8 +200,8 @@ function renderGeneratedPanelCopy(snapshot, positionControl = null) {
     </div>`;
   }).join('');
   const switchMarkup = renderSwitchSection(snapshot, positionControl);
-  const inputsMarkup = renderSocketList('Inputs', panel.inputs, panelPositions.inputs);
-  const outputsMarkup = renderSocketList('Outputs', panel.outputs, panelPositions.outputs);
+  const inputsMarkup = renderSocketList('Inputs', panel.inputs, panelPositions.inputs, { showEmpty: true });
+  const outputsMarkup = renderSocketList('Outputs', panel.outputs, panelPositions.outputs, { showEmpty: true });
   const ledsMarkup = renderLedList(snapshot.leds);
 
   return `<div class="program-card-use__reference">
@@ -291,8 +291,9 @@ function renderPanelRail(card, panelImg) {
   return `<aside class="program-card-panel-rail" aria-label="Panel visualization">${panels}</aside>`;
 }
 
-function renderSocketList(title, sockets, positions) {
-  if (!sockets) return '';
+function renderSocketList(title, sockets, positions, { showEmpty = false } = {}) {
+  if (!sockets && !showEmpty) return '';
+  sockets ||= {};
   const items = (positions || []).map(pos => {
     const socket = sockets[pos.key];
     if (!socket || (!socket.description && !socket.label)) {
@@ -303,7 +304,7 @@ function renderSocketList(title, sockets, positions) {
       ${socket.label || socket.description ? `<p>${socket.label ? `<span class="program-card-component-role">${esc(inline(socket.label))}</span>` : ''}${socket.label && socket.description ? '<br>' : ''}${socket.description ? esc(truncate(socket.description, PANEL_DESCRIPTION_THRESHOLD)) : ''}</p>` : ''}
     </div>`;
   }).join('');
-  if (!Object.values(sockets).some(socket => socket && (socket.description || socket.label))) return '';
+  if (!showEmpty && !Object.values(sockets).some(socket => socket && (socket.description || socket.label))) return '';
   return `<section class="program-card-socket-section program-card-socket-section--${esc(title.toLowerCase())}"><h4 class="program-card-socket-section__heading">${esc(title)}</h4><div class="program-card-socket-list">${items}</div></section>`;
 }
 

--- a/tools/sitegen/src/validate/prRules.js
+++ b/tools/sitegen/src/validate/prRules.js
@@ -244,6 +244,15 @@ export async function evaluatePrRules(changes, { root, baseFlairs = null }) {
       continue;
     }
     const releaseFiles = walkFiles(releaseDir);
+    const infoPath = path.join(releaseDir, 'info.yaml');
+    let rawInfo = {};
+    try {
+      rawInfo = YAML.parse(fs.readFileSync(infoPath, 'utf8')) || {};
+    } catch {}
+    if (rawInfo.draft === true) {
+      diagnostics.push(diagnostic('warning', 'draft-card-changed', `releases/${release}/info.yaml`,
+        `Release ${release} is marked draft: true.`));
+    }
     const readme = path.join(releaseDir, 'README.md');
     if (!fs.existsSync(readme) || !fs.statSync(readme).isFile()) {
       diagnostics.push(diagnostic('warning', 'release-readme-recommended', `releases/${release}`,
@@ -253,10 +262,6 @@ export async function evaluatePrRules(changes, { root, baseFlairs = null }) {
     const panelsDir = path.join(releaseDir, 'panels');
     if (fs.existsSync(panelsDir)) {
       const panels = await discoverCustomPanels(releaseDir, '', { copyAssets: false });
-      let rawInfo = {};
-      try {
-        rawInfo = YAML.parse(fs.readFileSync(path.join(releaseDir, 'info.yaml'), 'utf8')) || {};
-      } catch {}
       const panelDiagnostics = [
         ...panels.diagnostics,
         ...validateCustomPanelReferences(rawInfo, panels.panels),

--- a/tools/sitegen/test/pr-rules.test.js
+++ b/tools/sitegen/test/pr-rules.test.js
@@ -213,6 +213,20 @@ test('release without a local README warns', async t => {
     item.ruleId === 'release-readme-recommended' && item.severity === 'warning'));
 });
 
+test('changes to a draft release warn even when info.yaml is not the changed file', async t => {
+  const root = await fixture(t);
+  await write(root, 'releases/42_card/info.yaml', 'Name: Card\ndraft: true\n');
+  await write(root, 'releases/42_card/README.md', '# Card');
+  await write(root, 'releases/42_card/card.uf2', 'firmware');
+  const diagnostics = await evaluatePrRules([
+    { status: 'M', path: 'releases/42_card/card.uf2' },
+  ], { root });
+  assert.ok(diagnostics.some(item =>
+    item.ruleId === 'draft-card-changed'
+    && item.file === 'releases/42_card/info.yaml'
+    && item.severity === 'warning'));
+});
+
 test('existing UF2 in a nested release subdirectory satisfies the firmware rule', async t => {
   const root = await fixture(t);
   await write(root, 'releases/42_card/info.yaml', 'Name: Card');

--- a/tools/sitegen/test/render.test.js
+++ b/tools/sitegen/test/render.test.js
@@ -54,6 +54,20 @@ test('generated socket descriptions preserve unused physical jack positions', ()
   assert.match(html, /Audio 1[\s\S]*program-card-socket--empty" aria-hidden="true"><span>Unused<\/span>[\s\S]*CV 1/);
 });
 
+test('generated panels render unused positions when no inputs or outputs are defined', () => {
+  const generated = card({
+    panel_views: {
+      source: 'generated', default: 'middle', items: [{
+        id: 'middle', name: 'Middle', panel: {}, switch_modes: {}, leds: [],
+      }],
+    },
+  });
+  const html = renderCardArticle({ card: generated, panelImg: 'panel.svg', yamlUrl: 'source.yaml' });
+  assert.match(html, /program-card-socket-section--inputs/);
+  assert.match(html, /program-card-socket-section--outputs/);
+  assert.equal((html.match(/program-card-socket--empty/g) || []).length, 12);
+});
+
 test('tap labels the panel down position only when no down mode is provided', () => {
   const tapOnly = renderPanelArtwork({ panel: {}, switch_modes: { tap: 'Tap Tempo: Set the clock' } }, 'panel.svg');
   assert.match(tapOnly, /program-card-panel-switch-position--down[^>]*aria-label="down switch position: Tap Tempo"[^>]*>[\s\S]*<strong>Tap Tempo<\/strong>/);


### PR DESCRIPTION
This pull request introduces improvements to how unused panel inputs and outputs are rendered for releases, enhances the validation logic for draft releases, and adds corresponding tests to ensure these behaviors. The most important changes are grouped below.

**Panel rendering improvements:**

* Updated the panel rendering logic in `renderSocketList` and related calls so that unused input and output positions are now always shown, even when no inputs or outputs are defined in the panel (`cardPage.js`). This ensures the UI consistently displays all possible socket positions. [[1]](diffhunk://#diff-742331731aebd1ba6882a2330b5156eea3884c2eaceb4c5cd7ad5f6b13fea845L203-R204) [[2]](diffhunk://#diff-742331731aebd1ba6882a2330b5156eea3884c2eaceb4c5cd7ad5f6b13fea845L294-R296) [[3]](diffhunk://#diff-742331731aebd1ba6882a2330b5156eea3884c2eaceb4c5cd7ad5f6b13fea845L306-R307)
* Removed unused input definitions from the `panel.inputs` section in `info.yaml` for the USB MIDI Host release, reflecting that these are now handled by the renderer and do not need to be explicitly listed.

**Draft release validation:**

* Enhanced the PR validation logic so that any changes to a release marked as `draft: true` in `info.yaml` will generate a warning, even if `info.yaml` itself is not the changed file. [[1]](diffhunk://#diff-c039c90e9f2e36b6d1de749b6c50926dba08a1c77cbca1d61f445f8fef810118R247-R255) [[2]](diffhunk://#diff-c039c90e9f2e36b6d1de749b6c50926dba08a1c77cbca1d61f445f8fef810118L256-L259)
* Added a new test to verify that changing any file in a draft release triggers the appropriate warning.

**Testing and configuration:**

* Added a test to confirm that generated panels render all unused positions when no inputs or outputs are defined, ensuring the new rendering logic works as intended.
* Marked the USB MIDI Host release as published by setting `draft: false` in its `info.yaml`.