### PR TITLE
Set Creator to the author's name on Uncertainty and Scintillator

### DIFF
--- a/releases/106_uncertainty/README.md
+++ b/releases/106_uncertainty/README.md
@@ -151,6 +151,8 @@ the RP2 drive that appears (or via `picotool load`, or SWD).
   antialiasing technique the wavefolder uses.
 - **[Tom Whitwell](https://github.com/TomWhitwell) / Music Thing
   Modular** — the Workshop Computer platform this card runs on.
+- **Claude Code** (Anthropic) — wrote the firmware from the author's
+  brief.
 - **Don Buchla** — the 266 Source of Uncertainty, the 259 Complex
   Oscillator, and the Model 140 Timing Pulse Generator, whose ideas this
   card is a tribute to rather than a copy of.

--- a/releases/106_uncertainty/info.yaml
+++ b/releases/106_uncertainty/info.yaml
@@ -13,7 +13,7 @@ summary: |
   output respectively, with pot-pickup so returning to normal never snaps
   a value to wherever the knob was left.
 Language: C++ (Pico SDK)
-Creator: Claude Code
+Creator: Matt Allison
 Version: "1.0.0"
 Status: Released
 License: MIT

--- a/releases/107_scintillator/info.yaml
+++ b/releases/107_scintillator/info.yaml
@@ -15,7 +15,7 @@ summary: |
   "violence" setting both the odds of firing and the pulse width. Switch
   Up swaps Knob X/Y/MAIN into a simple 2-input mixer with a dry/wet blend.
 Language: C++ (Pico SDK)
-Creator: Matt Allison, with Claude Code (Anthropic)
+Creator: Matt Allison
 Version: "1.0.0"
 Status: Released
 License: MIT


### PR DESCRIPTION
Both cards had a `Creator` field that indexes them on the catalogue site under something other than the person who designed them.

- **`releases/106_uncertainty`** — read `Creator: Claude Code`, i.e. the tool that wrote the firmware.
- **`releases/107_scintillator`** — read `Creator: Matt Allison, with Claude Code (Anthropic)`. It's a single free-text field, so the compound value became its own creator entry rather than filing under the author. This fix was written for #401 but that merged before it landed, so it's carried over here.

Both now read `Creator: Matt Allison`.

**The AI disclosure the directive asks for is preserved in both.** Scintillator already has a "How this was built" section and credits Claude Code in its credits list. Uncertainty had no such mention anywhere — that `Creator` field was its only one — so this adds Claude Code to its README credits, matching how Scintillator records it.

Three files, four lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)